### PR TITLE
feat: support clipboard image paste in sidebar TUI

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,8 @@ export type WebviewMessage =
   | { type: "filesDropped"; files: string[]; shiftKey: boolean }
   | { type: "getClipboard" }
   | { type: "setClipboard"; text: string }
-  | { type: "triggerPaste" };
+  | { type: "triggerPaste" }
+  | { type: "imagePasted"; data: string; filename: string };
 
 export type HostMessage =
   | { type: "clipboardContent"; text: string }


### PR DESCRIPTION
## Summary

Fixes #12 — Clipboard image paste (e.g. GNOME screenshots) now works in the sidebar TUI.

## Problem

GNOME screenshot tool copies only an `image/png` blob to the clipboard with no text
representation. The existing paste handler calls `vscode.env.clipboard.readText()` which
returns empty for image-only clipboard content, so nothing gets pasted.

## Solution

Uses `navigator.clipboard.read()` (async Clipboard API) in the webview to detect
`image/png` clipboard items. The VS Code webview grants the `clipboard-read` permission,
so this works without any additional configuration.

**Flow:**
1. User presses Ctrl+V or Ctrl+Shift+V
2. Webview calls `navigator.clipboard.read()` and checks for `image/png`
3. If image found: converts blob to base64 via FileReader, sends to extension host
4. Extension host decodes base64, writes temp `.png` file, pastes the path via
   bracketed paste (same mechanism as normal clipboard paste)
5. OpenCode TUI recognizes the file path as an image attachment and shows `[Image]`
6. If no image found: falls through to existing `triggerPaste` text paste path

The text paste path (`triggerPaste`) is not a fallback for image failure — it's the
normal path for when the clipboard contains text instead of an image. Both paths are
exercised in normal usage.

## Files Changed

- `src/types.ts` — Added `imagePasted` message variant to `WebviewMessage`
- `src/webview/main.ts` — New `handlePasteWithImageSupport()` that tries image read
  before falling through to text paste
- `src/providers/OpenCodeTuiProvider.ts` — New `handleImagePasted()` that decodes
  base64, writes temp file, and pastes path via bracketed paste

## Testing

Tested on GNOME/Linux with screenshots copied to clipboard via the default screenshot
utility. Verified both image paste (shows `[Image]` in OpenCode) and text paste
(unchanged behavior) work correctly.