### PR TITLE
feat: support clipboard image paste in sidebar TUI

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,16 @@ export type WebviewMessage =
   | { type: "filesDropped"; files: string[]; shiftKey: boolean }
   | { type: "getClipboard" }
   | { type: "setClipboard"; text: string }
-  | { type: "triggerPaste" };
+  | { type: "triggerPaste" }
+  | { type: "imagePasted"; data: string };
+
+export const ALLOWED_IMAGE_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+];
+export const MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10MB
 
 export type HostMessage =
   | { type: "clipboardContent"; text: string }


### PR DESCRIPTION
## Summary

Fixes #12 — Clipboard image paste (e.g. GNOME screenshots) now works in the sidebar TUI.
Supersedes #13 (closed due to force-push sync issue).

## Problem

GNOME screenshot tool copies only an `image/png` blob to the clipboard with no text
representation. The existing paste handler calls `vscode.env.clipboard.readText()` which
returns empty for image-only clipboard content, so nothing gets pasted.

## Solution

Uses `navigator.clipboard.read()` (async Clipboard API) in the webview to detect
image clipboard items. The VS Code webview grants the `clipboard-read` permission,
so this works without any additional configuration.

**Flow:**
1. User presses Ctrl+V or Ctrl+Shift+V
2. Webview calls `navigator.clipboard.read()` and checks for allowed image types
3. If image found: validates size (10MB limit), converts blob to base64 via FileReader, sends to extension host
4. Extension host validates MIME type against whitelist, generates a unique filename with `randomUUID()`, writes temp file with exclusive creation flag (`wx`) and restrictive permissions (`0o600`), pastes the path via bracketed paste
5. OpenCode TUI recognizes the file path as an image attachment and shows `[Image]`
6. Temp file is cleaned up after 5 minutes
7. If no image found: falls through to existing `triggerPaste` text paste path

## Security

Addresses all security concerns raised in #13 review:

| Issue | Mitigation |
|-------|-----------|
| Path traversal | Filename generated server-side with `randomUUID()`, webview input ignored |
| Symlink attack | Exclusive creation flag `wx` (fails if file exists) + `mode: 0o600` |
| DoS via large image | 10MB limit enforced in both webview and extension host |
| SVG XSS | MIME whitelist: `png`, `jpeg`, `webp`, `gif` only |
| FileReader errors | `onerror`/`onabort` handlers fall back to text paste |
| Temp file cleanup | 5-minute delayed cleanup with logged success/failure |

## Files Changed

- `src/types.ts` — Added `imagePasted` message variant to `WebviewMessage`
- `src/webview/main.ts` — New `handlePasteWithImageSupport()` with size limit, MIME whitelist, FileReader error handling
- `src/providers/OpenCodeTuiProvider.ts` — New `handleImagePasted()` with MIME validation, size check, `randomUUID()` filename, exclusive file creation, and timed cleanup

## Testing

Tested on GNOME/Linux with screenshots copied to clipboard via the default screenshot
utility. Verified both image paste (shows `[Image]` in OpenCode) and text paste
(unchanged behavior) work correctly.