### PR TITLE
fix: support Shift+Enter for newline in sidebar terminal

### DIFF
--- a/src/webview/terminal/index.ts
+++ b/src/webview/terminal/index.ts
@@ -49,7 +49,13 @@ export function initTerminal(
   });
 
   const keyboardHandler = createKeyboardHandler();
-  terminal.attachCustomKeyEventHandler(keyboardHandler.handler);
+  terminal.attachCustomKeyEventHandler((event) => {
+    if (event.key === "Enter" && event.shiftKey) {
+      terminal.write("\r\n");
+      return false;
+    }
+    return keyboardHandler.handler(event);
+  });
 
   const fitAddon = new FitAddon();
   terminal.loadAddon(fitAddon);

--- a/src/webview/terminal/index.ts
+++ b/src/webview/terminal/index.ts
@@ -49,7 +49,7 @@ export function initTerminal(
   });
 
   const keyboardHandler = createKeyboardHandler({
-    write: (data) => terminal.write(data),
+    sendInput: (data) => options.onData(data),
   });
   terminal.attachCustomKeyEventHandler(keyboardHandler.handler);
 

--- a/src/webview/terminal/index.ts
+++ b/src/webview/terminal/index.ts
@@ -48,14 +48,10 @@ export function initTerminal(
     scrollback: config.scrollback,
   });
 
-  const keyboardHandler = createKeyboardHandler();
-  terminal.attachCustomKeyEventHandler((event) => {
-    if (event.key === "Enter" && event.shiftKey) {
-      terminal.write("\r\n");
-      return false;
-    }
-    return keyboardHandler.handler(event);
+  const keyboardHandler = createKeyboardHandler({
+    write: (data) => terminal.write(data),
   });
+  terminal.attachCustomKeyEventHandler(keyboardHandler.handler);
 
   const fitAddon = new FitAddon();
   terminal.loadAddon(fitAddon);

--- a/src/webview/terminal/keyboard.test.ts
+++ b/src/webview/terminal/keyboard.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createKeyboardHandler } from "./keyboard";
 
 const createKeyboardEvent = (
@@ -177,6 +177,65 @@ describe("createKeyboardHandler", () => {
       const winEvent = makeEvent();
       expect(winKeyboard.handler(winEvent)).toBe(true);
       expect(winEvent.defaultPrevented).toBe(true);
+    });
+  });
+
+  describe("Shift+Enter handling", () => {
+    it("sends \\r\\n through sendInput on Shift+Enter", () => {
+      const sendInput = vi.fn();
+      const keyboard = createKeyboardHandler({ isMac: true, sendInput });
+
+      const event = createKeyboardEvent({
+        key: "Enter",
+        code: "Enter",
+        shiftKey: true,
+      });
+
+      expect(keyboard.handler(event)).toBe(false);
+      expect(event.defaultPrevented).toBe(true);
+      expect(sendInput).toHaveBeenCalledWith("\r\n");
+    });
+
+    it("does not intercept Shift+Enter when modifiers are held", () => {
+      const sendInput = vi.fn();
+      const keyboard = createKeyboardHandler({ isMac: true, sendInput });
+
+      const event = createKeyboardEvent({
+        key: "Enter",
+        code: "Enter",
+        shiftKey: true,
+        ctrlKey: true,
+      });
+
+      expect(keyboard.handler(event)).toBe(true);
+      expect(sendInput).not.toHaveBeenCalled();
+    });
+
+    it("ignores Shift+Enter on keyup", () => {
+      const sendInput = vi.fn();
+      const keyboard = createKeyboardHandler({ isMac: true, sendInput });
+
+      const event = new KeyboardEvent("keyup", {
+        key: "Enter",
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+
+      expect(keyboard.handler(event)).toBe(true);
+      expect(sendInput).not.toHaveBeenCalled();
+    });
+
+    it("does not intercept Shift+Enter when sendInput is not provided", () => {
+      const keyboard = createKeyboardHandler({ isMac: true });
+
+      const event = createKeyboardEvent({
+        key: "Enter",
+        code: "Enter",
+        shiftKey: true,
+      });
+
+      expect(keyboard.handler(event)).toBe(true);
     });
   });
 });

--- a/src/webview/terminal/keyboard.test.ts
+++ b/src/webview/terminal/keyboard.test.ts
@@ -196,7 +196,7 @@ describe("createKeyboardHandler", () => {
       expect(sendInput).toHaveBeenCalledWith("\r\n");
     });
 
-    it("does not intercept Shift+Enter when modifiers are held", () => {
+    it("does not intercept Shift+Enter when Ctrl is held", () => {
       const sendInput = vi.fn();
       const keyboard = createKeyboardHandler({ isMac: true, sendInput });
 
@@ -205,6 +205,36 @@ describe("createKeyboardHandler", () => {
         code: "Enter",
         shiftKey: true,
         ctrlKey: true,
+      });
+
+      expect(keyboard.handler(event)).toBe(true);
+      expect(sendInput).not.toHaveBeenCalled();
+    });
+
+    it("does not intercept Shift+Enter when Alt is held", () => {
+      const sendInput = vi.fn();
+      const keyboard = createKeyboardHandler({ isMac: true, sendInput });
+
+      const event = createKeyboardEvent({
+        key: "Enter",
+        code: "Enter",
+        shiftKey: true,
+        altKey: true,
+      });
+
+      expect(keyboard.handler(event)).toBe(true);
+      expect(sendInput).not.toHaveBeenCalled();
+    });
+
+    it("does not intercept Shift+Enter when Meta is held", () => {
+      const sendInput = vi.fn();
+      const keyboard = createKeyboardHandler({ isMac: true, sendInput });
+
+      const event = createKeyboardEvent({
+        key: "Enter",
+        code: "Enter",
+        shiftKey: true,
+        metaKey: true,
       });
 
       expect(keyboard.handler(event)).toBe(true);
@@ -236,6 +266,21 @@ describe("createKeyboardHandler", () => {
       });
 
       expect(keyboard.handler(event)).toBe(true);
+    });
+
+    it("sends \\r\\n on Windows/Linux Shift+Enter", () => {
+      const sendInput = vi.fn();
+      const keyboard = createKeyboardHandler({ isMac: false, sendInput });
+
+      const event = createKeyboardEvent({
+        key: "Enter",
+        code: "Enter",
+        shiftKey: true,
+      });
+
+      expect(keyboard.handler(event)).toBe(false);
+      expect(event.defaultPrevented).toBe(true);
+      expect(sendInput).toHaveBeenCalledWith("\r\n");
     });
   });
 });

--- a/src/webview/terminal/keyboard.ts
+++ b/src/webview/terminal/keyboard.ts
@@ -7,7 +7,7 @@ const isLetterOrDigitCode = (code: string): boolean =>
 
 export interface KeyboardHandlerOptions {
   isMac?: boolean;
-  write?: (data: string) => void;
+  sendInput?: (data: string) => void;
 }
 
 export function createKeyboardHandler(options: KeyboardHandlerOptions = {}) {
@@ -30,10 +30,10 @@ export function createKeyboardHandler(options: KeyboardHandlerOptions = {}) {
     event.key === "Enter" && event.shiftKey && !event.ctrlKey && !event.metaKey;
 
   const handler = (event: KeyboardEvent): boolean => {
-    if (isShiftEnter(event) && event.type === "keydown" && options.write) {
+    if (isShiftEnter(event) && event.type === "keydown" && options.sendInput) {
       event.preventDefault();
       event.stopPropagation();
-      options.write("\r\n");
+      options.sendInput("\r\n");
       return false;
     }
 

--- a/src/webview/terminal/keyboard.ts
+++ b/src/webview/terminal/keyboard.ts
@@ -6,7 +6,14 @@ const isLetterOrDigitCode = (code: string): boolean =>
   /^Key[A-Z]$/.test(code) || /^Digit[0-9]$/.test(code);
 
 export interface KeyboardHandlerOptions {
+  /** Whether the platform is macOS (auto-detected if omitted). */
   isMac?: boolean;
+  /**
+   * Callback to send input data through the PTY/host path.
+   * When provided, Shift+Enter sends `\r\n` (multiline newline) via this
+   * callback instead of through xterm's default key processing.
+   * When omitted, Shift+Enter is not intercepted.
+   */
   sendInput?: (data: string) => void;
 }
 
@@ -26,8 +33,13 @@ export function createKeyboardHandler(options: KeyboardHandlerOptions = {}) {
     (event.ctrlKey || event.metaKey) &&
     isLetterOrDigitCode(event.code);
 
+  /** Detect bare Shift+Enter without Ctrl/Meta/Alt modifiers. */
   const isShiftEnter = (event: KeyboardEvent): boolean =>
-    event.key === "Enter" && event.shiftKey && !event.ctrlKey && !event.metaKey;
+    event.key === "Enter" &&
+    event.shiftKey &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.altKey;
 
   const handler = (event: KeyboardEvent): boolean => {
     if (isShiftEnter(event) && event.type === "keydown" && options.sendInput) {

--- a/src/webview/terminal/keyboard.ts
+++ b/src/webview/terminal/keyboard.ts
@@ -7,6 +7,7 @@ const isLetterOrDigitCode = (code: string): boolean =>
 
 export interface KeyboardHandlerOptions {
   isMac?: boolean;
+  write?: (data: string) => void;
 }
 
 export function createKeyboardHandler(options: KeyboardHandlerOptions = {}) {
@@ -20,13 +21,23 @@ export function createKeyboardHandler(options: KeyboardHandlerOptions = {}) {
   const isPasteShortcut = (event: KeyboardEvent): boolean =>
     event.code === "KeyV" && !event.altKey && isWorkbenchPrimaryModifier(event);
 
-  const handler = (event: KeyboardEvent): boolean => {
-    const isLetterOrDigitChord =
-      !event.altKey &&
-      (event.ctrlKey || event.metaKey) &&
-      isLetterOrDigitCode(event.code);
+  const isLetterOrDigitChord = (event: KeyboardEvent): boolean =>
+    !event.altKey &&
+    (event.ctrlKey || event.metaKey) &&
+    isLetterOrDigitCode(event.code);
 
-    if (!isLetterOrDigitChord) {
+  const isShiftEnter = (event: KeyboardEvent): boolean =>
+    event.key === "Enter" && event.shiftKey && !event.ctrlKey && !event.metaKey;
+
+  const handler = (event: KeyboardEvent): boolean => {
+    if (isShiftEnter(event) && event.type === "keydown" && options.write) {
+      event.preventDefault();
+      event.stopPropagation();
+      options.write("\r\n");
+      return false;
+    }
+
+    if (!isLetterOrDigitChord(event)) {
       return true;
     }
 


### PR DESCRIPTION
**Title:** Fix Shift+Enter behavior in sidebar terminal

**Description:**

This PR fixes the behavior of `Shift+Enter` in the sidebar terminal (webview-based xterm).

Currently:

* `Enter` and `Shift+Enter` both send the command immediately

Expected behavior:

* `Enter` → execute command
* `Shift+Enter` → insert newline (for multiline input)

**Implementation:**

Wrap the existing `attachCustomKeyEventHandler` and intercept `Shift+Enter` before passing the event to the existing handler:

```ts
terminal.attachCustomKeyEventHandler((event) => {
  if (event.key === "Enter" && event.shiftKey) {
    terminal.write("\r\n");
    return false;
  }
  return keyboardHandler.handler(event);
});
```

This preserves all existing keybindings while adding multiline support.

**Why this is needed:**

In webview-based terminals (xterm.js), modifier keys like Shift are not handled by default for Enter, so both combinations produce the same input (`\r`).

This change aligns behavior with typical terminal UX.