### PR TITLE
feat: multi-backend terminal support (tmux, zellij, native)

### DIFF
--- a/package.json
+++ b/package.json
@@ -446,6 +446,21 @@
           "default": true,
           "description": "Enable tmux session management. Disable to use the extension with a plain terminal shell (no tmux required)."
         },
+        "opencodeTui.terminalBackend": {
+          "type": "string",
+          "default": "tmux",
+          "enum": [
+            "native",
+            "tmux",
+            "zellij"
+          ],
+          "description": "Preferred terminal backend. Unavailable backends safely fall back to native."
+        },
+        "opencodeTui.enableZellij": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable zellij session backend detection and session attach/create support."
+        },
         "opencodeTui.collapseSecondaryBarOnEditorOpen": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -441,11 +441,6 @@
           "default": true,
           "description": "Auto-spawn OpenCode if not running"
         },
-        "opencodeTui.enableTmux": {
-          "type": "boolean",
-          "default": true,
-          "description": "Enable tmux session management. Disable to use the extension with a plain terminal shell (no tmux required)."
-        },
         "opencodeTui.terminalBackend": {
           "type": "string",
           "default": "tmux",
@@ -454,12 +449,13 @@
             "tmux",
             "zellij"
           ],
-          "description": "Preferred terminal backend. Unavailable backends safely fall back to native."
-        },
-        "opencodeTui.enableZellij": {
-          "type": "boolean",
-          "default": true,
-          "description": "Enable zellij session backend detection and session attach/create support."
+          "enumDescriptions": [
+            "Native terminal — basic shell only, no multiplexer features (panes, tabs, sessions)",
+            "Tmux — full session, pane, and window management via tmux",
+            "Zellij — full session, pane, and tab management via zellij"
+          ],
+          "description": "Select the terminal backend. Unavailable backends safely fall back to native.",
+          "order": 1
         },
         "opencodeTui.collapseSecondaryBarOnEditorOpen": {
           "type": "boolean",
@@ -564,17 +560,7 @@
         "opencodeTui.defaultAiTool": {
           "type": "string",
           "default": "",
-          "description": "Name of the default AI tool to launch when creating a new tmux session"
-        },
-        "opencodeTui.nativeShellDefault": {
-          "type": "string",
-          "default": "",
-          "description": "Default behavior when switching to native shell. Empty = ask every time, 'shell' = default shell, or set any configured AI tool name such as 'opencode', 'claude', or 'codex'"
-        },
-        "opencodeTui.tmuxSessionDefault": {
-          "type": "string",
-          "default": "",
-          "description": "Default behavior when creating a new tmux session. Empty = ask every time, 'shell' = create without launching a tool, or set any configured AI tool name"
+          "description": "Name of the default AI tool to launch when creating a new terminal session"
         }
       }
     }

--- a/src/core/ExtensionLifecycle.ts
+++ b/src/core/ExtensionLifecycle.ts
@@ -330,7 +330,9 @@ export class ExtensionLifecycle {
     if (config.get<boolean>("autoFocusOnSend", true)) {
       vscode.commands.executeCommand("opencodeTui.focus");
       setTimeout(() => {
-        this.tuiProvider?.focus();
+        if (typeof this.tuiProvider?.focus === "function") {
+          this.tuiProvider.focus();
+        }
       }, 100);
     }
   }
@@ -394,7 +396,9 @@ export class ExtensionLifecycle {
     if (config.get<boolean>("autoFocusOnSend", true)) {
       vscode.commands.executeCommand("opencodeTui.focus");
       setTimeout(() => {
-        this.tuiProvider?.focus();
+        if (typeof this.tuiProvider?.focus === "function") {
+          this.tuiProvider.focus();
+        }
       }, 100);
     }
   }

--- a/src/core/ExtensionLifecycle.ts
+++ b/src/core/ExtensionLifecycle.ts
@@ -16,6 +16,11 @@ import { InstanceController } from "../services/InstanceController";
 import { PortManager } from "../services/PortManager";
 import { ConnectionResolver } from "../services/ConnectionResolver";
 import { TmuxSessionManager } from "../services/TmuxSessionManager";
+import { ZellijSessionManager } from "../services/ZellijSessionManager";
+import {
+  StaticTerminalBackend,
+  TerminalBackendRegistry,
+} from "../services/terminalBackends";
 import { TerminalDashboardProvider } from "../providers/TerminalDashboardProvider";
 import {
   registerCommands as registerAllCommands,
@@ -40,6 +45,8 @@ export class ExtensionLifecycle {
   private instanceController: InstanceController | undefined;
   private portManager: PortManager | undefined;
   private tmuxSessionManager: TmuxSessionManager | undefined;
+  private zellijSessionManager: ZellijSessionManager | undefined;
+  private backendRegistry: TerminalBackendRegistry | undefined;
   private terminalDashboardProvider: TerminalDashboardProvider | undefined;
   private activated = false;
   private tuiProviderRegistration: vscode.Disposable | undefined;
@@ -121,6 +128,28 @@ export class ExtensionLifecycle {
           "[ExtensionLifecycle] tmux disabled by opencodeTui.enableTmux setting; using native terminal shell behavior",
         );
       }
+      const enableZellij = vscode.workspace
+        .getConfiguration("opencodeTui")
+        .get<boolean>("enableZellij", true);
+      if (enableZellij) {
+        const zellijSessionManager = new ZellijSessionManager(logger);
+        if (await zellijSessionManager.isAvailable()) {
+          this.zellijSessionManager = zellijSessionManager;
+        } else {
+          logger.info(
+            "[ExtensionLifecycle] zellij not detected; zellij backend unavailable",
+          );
+        }
+      }
+      this.backendRegistry = new TerminalBackendRegistry([
+        new StaticTerminalBackend("native", "Native", true),
+        new StaticTerminalBackend("tmux", "Tmux", !!this.tmuxSessionManager),
+        new StaticTerminalBackend(
+          "zellij",
+          "Zellij",
+          !!this.zellijSessionManager,
+        ),
+      ]);
       this.instanceRegistry = new InstanceRegistry(context);
       this.instanceRegistry.hydrate(this.instanceStore);
 
@@ -158,6 +187,8 @@ export class ExtensionLifecycle {
         this.portManager,
         this.instanceStore,
         this.tmuxSessionManager,
+        this.zellijSessionManager,
+        this.backendRegistry,
       );
 
       // Register webview provider — guard against double-registration on fast

--- a/src/core/ExtensionLifecycle.ts
+++ b/src/core/ExtensionLifecycle.ts
@@ -110,35 +110,22 @@ export class ExtensionLifecycle {
 
       this.instanceStore = new InstanceStore();
       this.portManager = new PortManager(this.instanceStore);
-      const enableTmux = vscode.workspace
-        .getConfiguration("opencodeTui")
-        .get<boolean>("enableTmux", true);
-      if (enableTmux) {
-        const tmuxSessionManager = new TmuxSessionManager(logger);
-        if (await tmuxSessionManager.isAvailable()) {
-          this.tmuxSessionManager = tmuxSessionManager;
-        } else {
-          logger.info(
-            "[ExtensionLifecycle] tmux not detected; using native terminal shell behavior",
-          );
-        }
+      const tmuxSessionManager = new TmuxSessionManager(logger);
+      if (await tmuxSessionManager.isAvailable()) {
+        this.tmuxSessionManager = tmuxSessionManager;
       } else {
         logger.info(
-          "[ExtensionLifecycle] tmux disabled by opencodeTui.enableTmux setting; using native terminal shell behavior",
+          "[ExtensionLifecycle] tmux not detected; tmux backend unavailable",
         );
       }
-      const enableZellij = vscode.workspace
-        .getConfiguration("opencodeTui")
-        .get<boolean>("enableZellij", true);
-      if (enableZellij) {
-        const zellijSessionManager = new ZellijSessionManager(logger);
-        if (await zellijSessionManager.isAvailable()) {
-          this.zellijSessionManager = zellijSessionManager;
-        } else {
-          logger.info(
-            "[ExtensionLifecycle] zellij not detected; zellij backend unavailable",
-          );
-        }
+
+      const zellijSessionManager = new ZellijSessionManager(logger);
+      if (await zellijSessionManager.isAvailable()) {
+        this.zellijSessionManager = zellijSessionManager;
+      } else {
+        logger.info(
+          "[ExtensionLifecycle] zellij not detected; zellij backend unavailable",
+        );
       }
       this.backendRegistry = new TerminalBackendRegistry([
         new StaticTerminalBackend("native", "Native", true),

--- a/src/core/ExtensionLifecycle.ts
+++ b/src/core/ExtensionLifecycle.ts
@@ -5,7 +5,6 @@ import { TerminalManager } from "../terminals/TerminalManager";
 import { OutputCaptureManager } from "../services/OutputCaptureManager";
 import { ContextSharingService } from "../services/ContextSharingService";
 import { ContextManager } from "../services/ContextManager";
-import type { ILogger } from "../services/ILogger";
 import { OutputChannelService } from "../services/OutputChannelService";
 import { InstanceDiscoveryService } from "../services/InstanceDiscoveryService";
 import { OpenCodeApiClient } from "../services/OpenCodeApiClient";
@@ -284,6 +283,9 @@ export class ExtensionLifecycle {
       },
       get tmuxManager() {
         return self.tmuxSessionManager;
+      },
+      get zellijManager() {
+        return self.zellijSessionManager;
       },
       get terminalManager() {
         return self.terminalManager;

--- a/src/core/ExtensionLifecycle.ts
+++ b/src/core/ExtensionLifecycle.ts
@@ -233,6 +233,7 @@ export class ExtensionLifecycle {
           logger,
           this.instanceStore,
           this.tuiProvider,
+          this.zellijSessionManager,
         );
 
         context.subscriptions.push(

--- a/src/core/commands/index.ts
+++ b/src/core/commands/index.ts
@@ -3,11 +3,7 @@ import type { ContextManager } from "../../services/ContextManager";
 import type { ContextSharingService } from "../../services/ContextSharingService";
 import type { InstanceController } from "../../services/InstanceController";
 import type { InstanceQuickPick } from "../../services/InstanceQuickPick";
-import type { InstanceStore } from "../../services/InstanceStore";
-import type { OutputChannelService } from "../../services/OutputChannelService";
 import type { TerminalManager } from "../../terminals/TerminalManager";
-import type { TerminalProvider } from "../../providers/TerminalProvider";
-import type { TmuxSessionManager } from "../../services/TmuxSessionManager";
 import {
   registerTerminalCommands,
   type TerminalCommandDependencies,
@@ -25,18 +21,16 @@ import {
   type DashboardCommandDependencies,
 } from "./dashboardCommands";
 
-export interface RegisterCommandDependencies
-  extends
-    TerminalCommandDependencies,
-    TmuxSessionCommandDependencies,
-    TmuxPaneCommandDependencies,
-    DashboardCommandDependencies {
+export type RegisterCommandDependencies = TerminalCommandDependencies &
+  TmuxSessionCommandDependencies &
+  TmuxPaneCommandDependencies &
+  DashboardCommandDependencies & {
   terminalManager: TerminalManager | undefined;
   contextSharingService: ContextSharingService | undefined;
   contextManager: ContextManager | undefined;
   instanceController: InstanceController | undefined;
   instanceQuickPick: InstanceQuickPick | undefined;
-}
+};
 
 export function registerCommands(
   context: vscode.ExtensionContext,

--- a/src/core/commands/tmuxPaneCommands.test.ts
+++ b/src/core/commands/tmuxPaneCommands.test.ts
@@ -6,6 +6,12 @@ import {
   type TmuxPane,
 } from "../../services/TmuxSessionManager";
 import type { TerminalProvider } from "../../providers/TerminalProvider";
+import { InstanceStore } from "../../services/InstanceStore";
+import {
+  ZellijSessionManager,
+  type ZellijPane,
+  type ZellijTab,
+} from "../../services/ZellijSessionManager";
 import {
   registerTmuxPaneCommands,
   type TmuxPaneCommandDependencies,
@@ -53,6 +59,25 @@ type Harness = {
   killSession: ReturnType<typeof vi.fn>;
 };
 
+type ZellijHarness = {
+  deps: TmuxPaneCommandDependencies;
+  zellijManager: ZellijSessionManager;
+  handlers: Map<string, RegisteredCommandHandler>;
+  selectPane: ReturnType<typeof vi.fn>;
+  listPanes: ReturnType<typeof vi.fn>;
+  splitPane: ReturnType<typeof vi.fn>;
+  sendTextToPane: ReturnType<typeof vi.fn>;
+  resizePane: ReturnType<typeof vi.fn>;
+  killPane: ReturnType<typeof vi.fn>;
+  nextTab: ReturnType<typeof vi.fn>;
+  prevTab: ReturnType<typeof vi.fn>;
+  createTab: ReturnType<typeof vi.fn>;
+  listTabs: ReturnType<typeof vi.fn>;
+  killTab: ReturnType<typeof vi.fn>;
+  selectTab: ReturnType<typeof vi.fn>;
+  killSession: ReturnType<typeof vi.fn>;
+};
+
 const defaultPanes: TmuxPane[] = [
   {
     paneId: "%1",
@@ -81,6 +106,16 @@ const defaultWindows: WindowEntry[] = [
     name: "logs",
     isActive: false,
   },
+];
+
+const defaultZellijPanes: ZellijPane[] = [
+  { id: "terminal_1", title: "editor", isFocused: true, isFloating: false },
+  { id: "terminal_2", title: "shell", isFocused: false, isFloating: false },
+];
+
+const defaultZellijTabs: ZellijTab[] = [
+  { index: 1, name: "main", isActive: true },
+  { index: 2, name: "logs", isActive: false },
 ];
 
 function createHarness(options?: {
@@ -150,6 +185,8 @@ function createHarness(options?: {
 
   const deps: TmuxPaneCommandDependencies = {
     tmuxManager,
+    zellijManager: undefined,
+    instanceStore: undefined,
     resolveActiveTmuxSessionId,
     resolveActiveTmuxFocus,
     resolveWorkspacePath: vi.fn(() => "/test/workspace"),
@@ -189,6 +226,103 @@ function createHarness(options?: {
   };
 }
 
+function createZellijHarness(options?: {
+  sessionId?: string | undefined;
+  panes?: ZellijPane[];
+  tabs?: ZellijTab[];
+}): ZellijHarness {
+  const zellijManager = new ZellijSessionManager();
+  const tmuxManager = new TmuxSessionManager();
+  const provider = new vscodeMock.Disposable(
+    () => {},
+  ) as unknown as TerminalProvider;
+  const instanceStore = new InstanceStore();
+  instanceStore.upsert({
+    config: { id: "instance-1", label: "Instance 1" },
+    runtime: {
+      terminalBackend: "zellij",
+      zellijSessionId:
+        options && "sessionId" in options ? options.sessionId : "zellij-1",
+    },
+    state: "connected",
+  });
+
+  const selectPane = vi
+    .spyOn(zellijManager, "selectPane")
+    .mockResolvedValue(undefined);
+  const listPanes = vi
+    .spyOn(zellijManager, "listPanes")
+    .mockResolvedValue(options?.panes ?? defaultZellijPanes);
+  const splitPane = vi
+    .spyOn(zellijManager, "splitPane")
+    .mockResolvedValue("terminal_new");
+  const sendTextToPane = vi
+    .spyOn(zellijManager, "sendTextToPane")
+    .mockResolvedValue(undefined);
+  const resizePane = vi
+    .spyOn(zellijManager, "resizePane")
+    .mockResolvedValue(undefined);
+  const killPane = vi
+    .spyOn(zellijManager, "killPane")
+    .mockResolvedValue(undefined);
+  const nextTab = vi.spyOn(zellijManager, "nextTab").mockResolvedValue(undefined);
+  const prevTab = vi.spyOn(zellijManager, "prevTab").mockResolvedValue(undefined);
+  const createTab = vi
+    .spyOn(zellijManager, "createTab")
+    .mockResolvedValue(undefined);
+  const listTabs = vi
+    .spyOn(zellijManager, "listTabs")
+    .mockResolvedValue(options?.tabs ?? defaultZellijTabs);
+  const killTab = vi.spyOn(zellijManager, "killTab").mockResolvedValue(undefined);
+  const selectTab = vi
+    .spyOn(zellijManager, "selectTab")
+    .mockResolvedValue(undefined);
+  const killSession = vi
+    .spyOn(zellijManager, "killSession")
+    .mockResolvedValue(undefined);
+  const tmuxSplitPane = vi.spyOn(tmuxManager, "splitPane");
+
+  const deps: TmuxPaneCommandDependencies = {
+    tmuxManager,
+    zellijManager,
+    instanceStore,
+    resolveActiveTmuxSessionId: vi.fn(() => undefined),
+    resolveActiveTmuxFocus: vi.fn(async () => undefined),
+    resolveWorkspacePath: vi.fn(() => "/test/workspace"),
+    provider,
+  };
+  registerTmuxPaneCommands(deps);
+
+  const handlers = new Map(
+    vi
+      .mocked(vscode.commands.registerCommand)
+      .mock.calls.map(([id, callback]) => [
+        id,
+        callback as RegisteredCommandHandler,
+      ]),
+  );
+  expect(tmuxSplitPane).not.toHaveBeenCalled();
+
+  return {
+    deps,
+    zellijManager,
+    handlers,
+    selectPane,
+    listPanes,
+    splitPane,
+    sendTextToPane,
+    resizePane,
+    killPane,
+    nextTab,
+    prevTab,
+    createTab,
+    listTabs,
+    killTab,
+    selectTab,
+    killSession,
+  };
+}
+
 function panePick(paneId: string, label: string, description: string) {
   return { label, description, paneId };
 }
@@ -212,7 +346,7 @@ function mockWarningOnce(value: string | undefined): void {
 }
 
 function getHandler(
-  harness: Harness,
+  harness: { handlers: Map<string, RegisteredCommandHandler> },
   commandId: string,
 ): RegisteredCommandHandler {
   const handler = harness.handlers.get(commandId);
@@ -600,6 +734,89 @@ describe("registerTmuxPaneCommands", () => {
     expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
       "Failed to kill session",
     );
+  });
+
+  it("routes pane operations to zellij when zellij is active", async () => {
+    const harness = createZellijHarness();
+
+    await getHandler(harness, "opencodeTui.tmuxSwitchPane")({
+      paneId: "terminal_2",
+    });
+    expect(harness.selectPane).toHaveBeenCalledWith("terminal_2");
+
+    await getHandler(harness, "opencodeTui.tmuxSplitPaneH")({
+      paneId: "terminal_1",
+      sessionId: "zellij-1",
+    });
+    expect(harness.selectPane).toHaveBeenLastCalledWith("terminal_1");
+    expect(harness.splitPane).toHaveBeenCalledWith("h", {
+      workingDirectory: "/test/workspace",
+    });
+
+    mockInputBoxOnce("pwd");
+    await getHandler(harness, "opencodeTui.tmuxSendTextToPane")({
+      paneId: "terminal_2",
+    });
+    expect(harness.selectPane).toHaveBeenLastCalledWith("terminal_2");
+    expect(harness.sendTextToPane).toHaveBeenCalledWith("pwd");
+
+    mockQuickPickOnce("Left");
+    mockInputBoxOnce("4");
+    await getHandler(harness, "opencodeTui.tmuxResizePane")({
+      paneId: "terminal_2",
+    });
+    expect(harness.resizePane).toHaveBeenCalledWith("left", 4);
+  });
+
+  it("routes zellij tab and session commands and disables swap", async () => {
+    const harness = createZellijHarness();
+
+    await getHandler(harness, "opencodeTui.tmuxNextWindow")();
+    await getHandler(harness, "opencodeTui.tmuxPrevWindow")();
+    await getHandler(harness, "opencodeTui.tmuxCreateWindow")();
+    expect(harness.nextTab).toHaveBeenCalledTimes(1);
+    expect(harness.prevTab).toHaveBeenCalledTimes(1);
+    expect(harness.createTab).toHaveBeenCalledWith({
+      workingDirectory: "/test/workspace",
+    });
+
+    mockQuickPickOnce(windowPick("2", "Tab 2: logs", "2"));
+    await getHandler(harness, "opencodeTui.tmuxSelectWindow")();
+    expect(harness.listTabs).toHaveBeenCalledTimes(1);
+    expect(harness.selectTab).toHaveBeenCalledWith(2);
+
+    mockWarningOnce("Kill");
+    await getHandler(harness, "opencodeTui.tmuxKillWindow")({ windowId: "2" });
+    expect(harness.selectTab).toHaveBeenLastCalledWith(2);
+    expect(harness.killTab).toHaveBeenCalledTimes(1);
+
+    await getHandler(harness, "opencodeTui.tmuxSwapPane")({
+      paneId: "terminal_1",
+    });
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+      "Swap pane is not supported for zellij",
+    );
+
+    mockWarningOnce("Kill");
+    await getHandler(harness, "opencodeTui.tmuxKillSession")();
+    expect(harness.killSession).toHaveBeenCalledWith("zellij-1");
+  });
+
+  it("no-ops pane commands for native backend", async () => {
+    const harness = createZellijHarness();
+    harness.deps.instanceStore?.upsert({
+      config: { id: "instance-1", label: "Instance 1" },
+      runtime: { terminalBackend: "native" },
+      state: "connected",
+    });
+
+    await getHandler(harness, "opencodeTui.tmuxSwitchPane")({
+      paneId: "terminal_2",
+    });
+    await getHandler(harness, "opencodeTui.tmuxNextWindow")();
+
+    expect(harness.selectPane).not.toHaveBeenCalled();
+    expect(harness.nextTab).not.toHaveBeenCalled();
   });
 
   it("refreshes the terminal manager", async () => {

--- a/src/core/commands/tmuxPaneCommands.ts
+++ b/src/core/commands/tmuxPaneCommands.ts
@@ -151,14 +151,20 @@ async function promptResizeDirectionAndAmount(): Promise<
   if (!direction) {
     return undefined;
   }
-  const dirFlag =
-    direction === "Left"
-      ? "L"
-      : direction === "Right"
-        ? "R"
-        : direction === "Up"
-          ? "U"
-          : "D";
+  const dirFlag: "L" | "R" | "U" | "D" = (() => {
+    switch (direction) {
+      case "Left":
+        return "L";
+      case "Right":
+        return "R";
+      case "Up":
+        return "U";
+      case "Down":
+        return "D";
+      default:
+        return "D";
+    }
+  })();
   const adjustment = await vscode.window.showInputBox({
     prompt: `Resize amount (cells) for ${direction.toLowerCase()}`,
     value: "5",

--- a/src/core/commands/tmuxPaneCommands.ts
+++ b/src/core/commands/tmuxPaneCommands.ts
@@ -4,6 +4,13 @@ import type {
   TmuxSessionManager,
 } from "../../services/TmuxSessionManager";
 import type { TerminalProvider } from "../../providers/TerminalProvider";
+import type { InstanceStore } from "../../services/InstanceStore";
+import type {
+  ZellijPane,
+  ZellijSessionManager,
+  ZellijTab,
+} from "../../services/ZellijSessionManager";
+import type { TerminalBackendType } from "../../types";
 
 type PaneQuickPickItem = {
   label: string;
@@ -13,6 +20,8 @@ type PaneQuickPickItem = {
 
 export interface TmuxPaneCommandDependencies {
   tmuxManager: TmuxSessionManager | undefined;
+  zellijManager?: ZellijSessionManager | undefined;
+  instanceStore: InstanceStore | undefined;
   resolveActiveTmuxSessionId: () => string | undefined;
   resolveActiveTmuxFocus: () => Promise<
     { sessionId: string; windowId: string; paneId: string } | undefined
@@ -20,6 +29,16 @@ export interface TmuxPaneCommandDependencies {
   resolveWorkspacePath: () => string | undefined;
   provider: TerminalProvider | undefined;
 }
+
+type BackendPaneManager =
+  | { kind: "tmux"; manager: TmuxSessionManager }
+  | { kind: "zellij"; manager: ZellijSessionManager };
+
+type WindowQuickPickItem = {
+  label: string;
+  description: string;
+  windowId: string;
+};
 
 function toPaneQuickPickItems(
   panes: TmuxPane[],
@@ -32,19 +51,72 @@ function toPaneQuickPickItems(
   }));
 }
 
+function toTmuxPaneFromZellijPane(pane: ZellijPane, index: number): TmuxPane {
+  return {
+    paneId: pane.id,
+    index,
+    title: pane.title,
+    isActive: pane.isFocused,
+  };
+}
+
+function getActiveBackend(
+  instanceStore: InstanceStore | undefined,
+): TerminalBackendType {
+  try {
+    return instanceStore?.getActive().runtime.terminalBackend ?? "tmux";
+  } catch {
+    return "tmux";
+  }
+}
+
+function getActiveZellijSessionId(
+  instanceStore: InstanceStore | undefined,
+): string | undefined {
+  try {
+    return instanceStore?.getActive().runtime.zellijSessionId;
+  } catch {
+    return undefined;
+  }
+}
+
+function getPaneManager(
+  deps: TmuxPaneCommandDependencies,
+): BackendPaneManager | undefined {
+  const backend = getActiveBackend(deps.instanceStore);
+  if (backend === "tmux") {
+    return deps.tmuxManager ? { kind: "tmux", manager: deps.tmuxManager } : undefined;
+  }
+  if (backend === "zellij") {
+    return deps.zellijManager
+      ? { kind: "zellij", manager: deps.zellijManager }
+      : undefined;
+  }
+  return undefined;
+}
+
 async function listTmuxPanes(
-  tmuxManager: TmuxSessionManager,
+  paneManager: BackendPaneManager,
   sessionId: string,
 ): Promise<TmuxPane[]> {
-  return tmuxManager.listPanes(sessionId);
+  if (paneManager.kind === "tmux") {
+    return paneManager.manager.listPanes(sessionId);
+  }
+  const panes = await paneManager.manager.listPanes();
+  return panes.map(toTmuxPaneFromZellijPane);
 }
 
 async function sendTextToTmuxPane(
-  tmuxManager: TmuxSessionManager,
+  paneManager: BackendPaneManager,
   paneId: string,
   text: string,
 ): Promise<void> {
-  await tmuxManager.sendTextToPane(paneId, text);
+  if (paneManager.kind === "tmux") {
+    await paneManager.manager.sendTextToPane(paneId, text);
+    return;
+  }
+  await paneManager.manager.selectPane(paneId);
+  await paneManager.manager.sendTextToPane(text);
 }
 
 async function pickPaneFromSession(
@@ -53,10 +125,11 @@ async function pickPaneFromSession(
   placeHolder: string,
   includeActiveMarker: boolean = false,
 ): Promise<PaneQuickPickItem | undefined> {
-  if (!deps.tmuxManager) {
+  const paneManager = getPaneManager(deps);
+  if (!paneManager) {
     return undefined;
   }
-  const panes = await listTmuxPanes(deps.tmuxManager, sessionId);
+  const panes = await listTmuxPanes(paneManager, sessionId);
   return vscode.window.showQuickPick<PaneQuickPickItem>(
     toPaneQuickPickItems(panes, includeActiveMarker),
     { placeHolder },
@@ -105,14 +178,97 @@ async function promptResizeDirectionAndAmount(): Promise<
 export function registerTmuxPaneCommands(
   deps: TmuxPaneCommandDependencies,
 ): vscode.Disposable[] {
+  function resolvePaneManager(): BackendPaneManager | undefined {
+    return getPaneManager(deps);
+  }
+
+  async function splitPane(
+    targetPaneId: string,
+    direction: "h" | "v",
+    options?: { command?: string; workingDirectory?: string },
+  ): Promise<void> {
+    const paneManager = resolvePaneManager();
+    if (!paneManager) return;
+    if (paneManager.kind === "tmux") {
+      await paneManager.manager.splitPane(targetPaneId, direction, options);
+      return;
+    }
+    await paneManager.manager.selectPane(targetPaneId);
+    await paneManager.manager.splitPane(direction, options);
+  }
+
+  async function resizePane(
+    paneId: string,
+    dirFlag: "L" | "R" | "U" | "D",
+    adjustment: number,
+  ): Promise<void> {
+    const paneManager = resolvePaneManager();
+    if (!paneManager) return;
+    if (paneManager.kind === "tmux") {
+      await paneManager.manager.resizePane(paneId, dirFlag, adjustment);
+      return;
+    }
+    const direction =
+      dirFlag === "L"
+        ? "left"
+        : dirFlag === "R"
+          ? "right"
+          : dirFlag === "U"
+            ? "up"
+            : "down";
+    await paneManager.manager.selectPane(paneId);
+    await paneManager.manager.resizePane(direction, adjustment);
+  }
+
+  async function listWindows(sessionId: string): Promise<WindowQuickPickItem[]> {
+    const paneManager = resolvePaneManager();
+    if (!paneManager) return [];
+    if (paneManager.kind === "tmux") {
+      const windows = await paneManager.manager.listWindows(sessionId);
+      return windows.map((w) => ({
+        label: `${w.isActive ? "$(check) " : ""}Window ${w.index}: ${w.name}`,
+        description: w.windowId,
+        windowId: w.windowId,
+      }));
+    }
+    const tabs = await paneManager.manager.listTabs();
+    return tabs.map((tab: ZellijTab) => ({
+      label: `${tab.isActive ? "$(check) " : ""}Tab ${tab.index}: ${tab.name}`,
+      description: String(tab.index),
+      windowId: String(tab.index),
+    }));
+  }
+
+  async function selectWindow(windowId: string): Promise<void> {
+    const paneManager = resolvePaneManager();
+    if (!paneManager) return;
+    if (paneManager.kind === "tmux") {
+      await paneManager.manager.selectWindow(windowId);
+      return;
+    }
+    await paneManager.manager.selectTab(Number(windowId));
+  }
+
+  async function killWindow(windowId: string): Promise<void> {
+    const paneManager = resolvePaneManager();
+    if (!paneManager) return;
+    if (paneManager.kind === "tmux") {
+      await paneManager.manager.killWindow(windowId);
+      return;
+    }
+    await paneManager.manager.selectTab(Number(windowId));
+    await paneManager.manager.killTab();
+  }
+
   const tmuxSwitchPaneCommand = vscode.commands.registerCommand(
     "opencodeTui.tmuxSwitchPane",
     async (item?: { paneId: string }) => {
-      if (!deps.tmuxManager) {
+      const paneManager = resolvePaneManager();
+      if (!paneManager) {
         return;
       }
       if (item?.paneId) {
-        await deps.tmuxManager.selectPane(item.paneId);
+        await paneManager.manager.selectPane(item.paneId);
         return;
       }
       const sessionId = await resolveFocusedSessionId();
@@ -124,7 +280,7 @@ export function registerTmuxPaneCommands(
         true,
       );
       if (selected) {
-        await deps.tmuxManager.selectPane(selected.paneId);
+        await paneManager.manager.selectPane(selected.paneId);
       }
     },
   );
@@ -132,14 +288,27 @@ export function registerTmuxPaneCommands(
   async function resolveFocusedContext(): Promise<
     { sessionId: string; paneId: string } | undefined
   > {
+    const paneManager = resolvePaneManager();
+    if (paneManager?.kind === "zellij") {
+      const sessionId = getActiveZellijSessionId(deps.instanceStore);
+      if (!sessionId) return undefined;
+      try {
+        const panes = await listTmuxPanes(paneManager, sessionId);
+        const active = panes.find((p) => p.isActive) ?? panes[0];
+        if (!active) return undefined;
+        return { sessionId, paneId: active.paneId };
+      } catch {
+        return undefined;
+      }
+    }
     const focus = await deps.resolveActiveTmuxFocus();
     if (focus) {
       return { sessionId: focus.sessionId, paneId: focus.paneId };
     }
     const sessionId = deps.resolveActiveTmuxSessionId();
-    if (!sessionId || !deps.tmuxManager) return undefined;
+    if (!sessionId || !paneManager) return undefined;
     try {
-      const panes = await deps.tmuxManager.listPanes(sessionId);
+      const panes = await listTmuxPanes(paneManager, sessionId);
       const active = panes.find((p) => p.isActive) ?? panes[0];
       if (!active) return undefined;
       return { sessionId, paneId: active.paneId };
@@ -149,6 +318,9 @@ export function registerTmuxPaneCommands(
   }
 
   async function resolveFocusedSessionId(): Promise<string | undefined> {
+    if (getActiveBackend(deps.instanceStore) === "zellij") {
+      return getActiveZellijSessionId(deps.instanceStore);
+    }
     const focus = await deps.resolveActiveTmuxFocus();
     return focus?.sessionId ?? deps.resolveActiveTmuxSessionId();
   }
@@ -156,7 +328,7 @@ export function registerTmuxPaneCommands(
   const tmuxSplitPaneHCommand = vscode.commands.registerCommand(
     "opencodeTui.tmuxSplitPaneH",
     async (item?: { paneId?: string; sessionId: string }) => {
-      if (!deps.tmuxManager) {
+      if (!resolvePaneManager()) {
         return;
       }
       let targetPaneId = item?.paneId;
@@ -167,7 +339,7 @@ export function registerTmuxPaneCommands(
       }
       try {
         const cwd = deps.resolveWorkspacePath();
-        await deps.tmuxManager.splitPane(targetPaneId, "h", {
+        await splitPane(targetPaneId, "h", {
           workingDirectory: cwd,
         });
       } catch {
@@ -179,7 +351,7 @@ export function registerTmuxPaneCommands(
   const tmuxSplitPaneVCommand = vscode.commands.registerCommand(
     "opencodeTui.tmuxSplitPaneV",
     async (item?: { paneId?: string; sessionId: string }) => {
-      if (!deps.tmuxManager) {
+      if (!resolvePaneManager()) {
         return;
       }
       let targetPaneId = item?.paneId;
@@ -190,7 +362,7 @@ export function registerTmuxPaneCommands(
       }
       try {
         const cwd = deps.resolveWorkspacePath();
-        await deps.tmuxManager.splitPane(targetPaneId, "v", {
+        await splitPane(targetPaneId, "v", {
           workingDirectory: cwd,
         });
       } catch {
@@ -202,7 +374,7 @@ export function registerTmuxPaneCommands(
   const tmuxSplitPaneWithCommandCommand = vscode.commands.registerCommand(
     "opencodeTui.tmuxSplitPaneWithCommand",
     async (item?: { paneId?: string; sessionId: string }) => {
-      if (!deps.tmuxManager) {
+      if (!resolvePaneManager()) {
         return;
       }
       const command = await vscode.window.showInputBox({
@@ -219,7 +391,7 @@ export function registerTmuxPaneCommands(
         targetPaneId = focused.paneId;
       }
       try {
-        await deps.tmuxManager.splitPane(targetPaneId, "v", {
+        await splitPane(targetPaneId, "v", {
           command,
           workingDirectory: deps.resolveWorkspacePath(),
         });
@@ -232,7 +404,8 @@ export function registerTmuxPaneCommands(
   const tmuxSendTextToPaneCommand = vscode.commands.registerCommand(
     "opencodeTui.tmuxSendTextToPane",
     async (item?: { paneId: string }) => {
-      if (!deps.tmuxManager) {
+      const paneManager = resolvePaneManager();
+      if (!paneManager) {
         return;
       }
       if (item?.paneId) {
@@ -240,7 +413,7 @@ export function registerTmuxPaneCommands(
           prompt: "Enter text to send to pane",
         });
         if (text) {
-          await sendTextToTmuxPane(deps.tmuxManager, item.paneId, text);
+          await sendTextToTmuxPane(paneManager, item.paneId, text);
         }
         return;
       }
@@ -255,7 +428,7 @@ export function registerTmuxPaneCommands(
         prompt: "Enter text to send",
       });
       if (text) {
-        await sendTextToTmuxPane(deps.tmuxManager, selected.paneId, text);
+        await sendTextToTmuxPane(paneManager, selected.paneId, text);
       }
     },
   );
@@ -263,7 +436,7 @@ export function registerTmuxPaneCommands(
   const tmuxResizePaneCommand = vscode.commands.registerCommand(
     "opencodeTui.tmuxResizePane",
     async (item?: { paneId: string }) => {
-      if (!deps.tmuxManager) {
+      if (!resolvePaneManager()) {
         return;
       }
       const paneId = item?.paneId;
@@ -282,7 +455,7 @@ export function registerTmuxPaneCommands(
         if (!resize) {
           return;
         }
-        await deps.tmuxManager.resizePane(
+        await resizePane(
           selected.paneId,
           resize.dirFlag,
           resize.adjustment,
@@ -295,7 +468,7 @@ export function registerTmuxPaneCommands(
         return;
       }
       try {
-        await deps.tmuxManager.resizePane(
+        await resizePane(
           paneId,
           resize.dirFlag,
           resize.adjustment,
@@ -309,14 +482,19 @@ export function registerTmuxPaneCommands(
   const tmuxSwapPaneCommand = vscode.commands.registerCommand(
     "opencodeTui.tmuxSwapPane",
     async (item?: { paneId: string }) => {
-      if (!deps.tmuxManager) {
+      const paneManager = resolvePaneManager();
+      if (!paneManager) {
+        return;
+      }
+      if (paneManager.kind === "zellij") {
+        vscode.window.showInformationMessage("Swap pane is not supported for zellij");
         return;
       }
       const sessionId = await resolveFocusedSessionId();
       if (!sessionId) {
         return;
       }
-      const panes = await listTmuxPanes(deps.tmuxManager, sessionId);
+      const panes = await listTmuxPanes(paneManager, sessionId);
       const sourcePaneId = item?.paneId;
       if (!sourcePaneId) {
         const selected = await vscode.window.showQuickPick<PaneQuickPickItem>(
@@ -338,7 +516,7 @@ export function registerTmuxPaneCommands(
           return;
         }
         try {
-          await deps.tmuxManager.swapPanes(selected.paneId, target.paneId);
+          await paneManager.manager.swapPanes(selected.paneId, target.paneId);
         } catch {
           vscode.window.showErrorMessage("Failed to swap panes");
         }
@@ -356,7 +534,7 @@ export function registerTmuxPaneCommands(
         return;
       }
       try {
-        await deps.tmuxManager.swapPanes(sourcePaneId, target.paneId);
+        await paneManager.manager.swapPanes(sourcePaneId, target.paneId);
       } catch {
         vscode.window.showErrorMessage("Failed to swap panes");
       }
@@ -366,15 +544,24 @@ export function registerTmuxPaneCommands(
   const tmuxKillPaneCommand = vscode.commands.registerCommand(
     "opencodeTui.tmuxKillPane",
     async (item?: { paneId: string }) => {
-      if (!deps.tmuxManager) {
+      const paneManager = resolvePaneManager();
+      if (!paneManager) {
         return;
       }
       const sessionId = await resolveFocusedSessionId();
       if (!sessionId) {
         return;
       }
-      const panes = await listTmuxPanes(deps.tmuxManager, sessionId);
+      const panes = await listTmuxPanes(paneManager, sessionId);
       const paneId = item?.paneId;
+      const killPane = async (targetPaneId: string) => {
+        if (paneManager.kind === "tmux") {
+          await paneManager.manager.killPane(targetPaneId);
+          return;
+        }
+        await paneManager.manager.selectPane(targetPaneId);
+        await paneManager.manager.killPane();
+      };
       if (!paneId) {
         if (panes.length <= 1) {
           vscode.window.showWarningMessage(
@@ -398,7 +585,7 @@ export function registerTmuxPaneCommands(
           return;
         }
         try {
-          await deps.tmuxManager.killPane(selected.paneId);
+          await killPane(selected.paneId);
         } catch {
           vscode.window.showErrorMessage("Failed to kill pane");
         }
@@ -419,7 +606,7 @@ export function registerTmuxPaneCommands(
         return;
       }
       try {
-        await deps.tmuxManager.killPane(paneId);
+        await killPane(paneId);
       } catch {
         vscode.window.showErrorMessage("Failed to kill pane");
       }
@@ -429,11 +616,16 @@ export function registerTmuxPaneCommands(
   const tmuxNextWindowCommand = vscode.commands.registerCommand(
     "opencodeTui.tmuxNextWindow",
     async () => {
-      if (!deps.tmuxManager) return;
+      const paneManager = resolvePaneManager();
+      if (!paneManager) return;
       const sessionId = await resolveFocusedSessionId();
       if (!sessionId) return;
       try {
-        await deps.tmuxManager.nextWindow(sessionId);
+        if (paneManager.kind === "tmux") {
+          await paneManager.manager.nextWindow(sessionId);
+        } else {
+          await paneManager.manager.nextTab();
+        }
       } catch {
         vscode.window.showErrorMessage("Failed to switch to next window");
       }
@@ -443,11 +635,16 @@ export function registerTmuxPaneCommands(
   const tmuxPrevWindowCommand = vscode.commands.registerCommand(
     "opencodeTui.tmuxPrevWindow",
     async () => {
-      if (!deps.tmuxManager) return;
+      const paneManager = resolvePaneManager();
+      if (!paneManager) return;
       const sessionId = await resolveFocusedSessionId();
       if (!sessionId) return;
       try {
-        await deps.tmuxManager.prevWindow(sessionId);
+        if (paneManager.kind === "tmux") {
+          await paneManager.manager.prevWindow(sessionId);
+        } else {
+          await paneManager.manager.prevTab();
+        }
       } catch {
         vscode.window.showErrorMessage("Failed to switch to previous window");
       }
@@ -457,11 +654,21 @@ export function registerTmuxPaneCommands(
   const tmuxCreateWindowCommand = vscode.commands.registerCommand(
     "opencodeTui.tmuxCreateWindow",
     async () => {
-      if (!deps.tmuxManager) return;
+      const paneManager = resolvePaneManager();
+      if (!paneManager) return;
       const sessionId = await resolveFocusedSessionId();
       if (!sessionId) return;
       try {
-        await deps.tmuxManager.createWindow(sessionId, deps.resolveWorkspacePath());
+        if (paneManager.kind === "tmux") {
+          await paneManager.manager.createWindow(
+            sessionId,
+            deps.resolveWorkspacePath(),
+          );
+        } else {
+          await paneManager.manager.createTab({
+            workingDirectory: deps.resolveWorkspacePath(),
+          });
+        }
       } catch {
         vscode.window.showErrorMessage("Failed to create window");
       }
@@ -471,18 +678,14 @@ export function registerTmuxPaneCommands(
   const tmuxKillWindowCommand = vscode.commands.registerCommand(
     "opencodeTui.tmuxKillWindow",
     async (item?: { windowId: string }) => {
-      if (!deps.tmuxManager) return;
+      if (!resolvePaneManager()) return;
       const sessionId = await resolveFocusedSessionId();
       if (!sessionId) return;
       let windowId = item?.windowId;
       if (!windowId) {
-        const windows = await deps.tmuxManager.listWindows(sessionId);
+        const windows = await listWindows(sessionId);
         const picked = await vscode.window.showQuickPick(
-          windows.map((w) => ({
-            label: `${w.isActive ? "$(check) " : ""}Window ${w.index}: ${w.name}`,
-            description: w.windowId,
-            windowId: w.windowId,
-          })),
+          windows,
           { placeHolder: "Select window to kill" },
         );
         if (!picked) return;
@@ -495,7 +698,7 @@ export function registerTmuxPaneCommands(
       );
       if (confirm !== "Kill") return;
       try {
-        await deps.tmuxManager.killWindow(windowId);
+        await killWindow(windowId);
       } catch {
         vscode.window.showErrorMessage("Failed to kill window");
       }
@@ -505,25 +708,21 @@ export function registerTmuxPaneCommands(
   const tmuxSelectWindowCommand = vscode.commands.registerCommand(
     "opencodeTui.tmuxSelectWindow",
     async (item?: { windowId: string }) => {
-      if (!deps.tmuxManager) return;
+      if (!resolvePaneManager()) return;
       const sessionId = await resolveFocusedSessionId();
       if (!sessionId) return;
       let windowId = item?.windowId;
       if (!windowId) {
-        const windows = await deps.tmuxManager.listWindows(sessionId);
+        const windows = await listWindows(sessionId);
         const picked = await vscode.window.showQuickPick(
-          windows.map((w) => ({
-            label: `${w.isActive ? "$(check) " : ""}Window ${w.index}: ${w.name}`,
-            description: w.windowId,
-            windowId: w.windowId,
-          })),
+          windows,
           { placeHolder: "Select window to switch to" },
         );
         if (!picked) return;
         windowId = picked.windowId;
       }
       try {
-        await deps.tmuxManager.selectWindow(windowId);
+        await selectWindow(windowId);
       } catch {
         vscode.window.showErrorMessage("Failed to select window");
       }
@@ -533,17 +732,18 @@ export function registerTmuxPaneCommands(
   const tmuxKillSessionCommand = vscode.commands.registerCommand(
     "opencodeTui.tmuxKillSession",
     async (item?: { sessionId: string }) => {
-      if (!deps.tmuxManager) return;
+      const paneManager = resolvePaneManager();
+      if (!paneManager) return;
       const sessionId = item?.sessionId ?? (await resolveFocusedSessionId());
       if (!sessionId) return;
       const confirm = await vscode.window.showWarningMessage(
-        `Kill tmux session "${sessionId}"?`,
+        `Kill ${paneManager.kind} session "${sessionId}"?`,
         { modal: true },
         "Kill",
       );
       if (confirm !== "Kill") return;
       try {
-        await deps.tmuxManager.killSession(sessionId);
+        await paneManager.manager.killSession(sessionId);
       } catch {
         vscode.window.showErrorMessage("Failed to kill session");
       }

--- a/src/core/commands/tmuxSessionCommands.test.ts
+++ b/src/core/commands/tmuxSessionCommands.test.ts
@@ -7,6 +7,7 @@ import { InstanceController } from "../../services/InstanceController";
 import { InstanceQuickPick } from "../../services/InstanceQuickPick";
 import { OutputChannelService } from "../../services/OutputChannelService";
 import { TmuxSessionManager } from "../../services/TmuxSessionManager";
+import { ZellijSessionManager } from "../../services/ZellijSessionManager";
 
 const vscode = await vi.importActual<typeof vscodeTypes>(
   "../../test/mocks/vscode",
@@ -39,6 +40,7 @@ type CommandHandlers = {
 function createProvider(): TerminalProvider {
   return Object.assign(Object.create(TerminalProvider.prototype), {
     switchToTmuxSession: vi.fn().mockResolvedValue(undefined),
+    switchToZellijSession: vi.fn().mockResolvedValue(undefined),
     createTmuxSession: vi.fn().mockResolvedValue(undefined),
     killTmuxSession: vi.fn().mockResolvedValue(undefined),
     switchToNativeShell: vi.fn().mockResolvedValue(undefined),
@@ -68,6 +70,14 @@ function createTmuxManager(
   sessions: SessionSummary[] = [],
 ): TmuxSessionManager {
   return Object.assign(Object.create(TmuxSessionManager.prototype), {
+    discoverSessions: vi.fn().mockResolvedValue(sessions),
+  });
+}
+
+function createZellijManager(
+  sessions: SessionSummary[] = [],
+): ZellijSessionManager {
+  return Object.assign(Object.create(ZellijSessionManager.prototype), {
     discoverSessions: vi.fn().mockResolvedValue(sessions),
   });
 }
@@ -667,6 +677,55 @@ describe("registerTmuxSessionCommands", () => {
     expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
       "opencodeTui.focus",
     );
+  });
+
+  it("browses and switches zellij sessions when zellij is the active backend", async () => {
+    const provider = createProvider();
+    const tmuxManager = createTmuxManager([
+      { id: "tmux-a", name: "tmux", workspace: "/tmux" },
+    ]);
+    const zellijManager = createZellijManager([
+      { id: "zellij-b", name: "beta", workspace: "/beta" },
+      { id: "zellij-a", name: "alpha", workspace: "/alpha" },
+    ]);
+    const instanceStore = createInstanceStore([
+      {
+        config: { id: "instance-1", label: "Instance 1" },
+        runtime: {
+          terminalBackend: "zellij",
+          zellijSessionId: "zellij-a",
+        },
+        state: "connected",
+      },
+    ]);
+    vi.mocked(vscode.window.showQuickPick).mockImplementation(async (items) => {
+      const quickPickItems = items as Array<{
+        label: string;
+        session: SessionSummary;
+      }>;
+      expect(quickPickItems.map((item) => item.label)).toEqual([
+        "alpha",
+        "beta",
+      ]);
+      return quickPickItems[1];
+    });
+
+    registerTmuxSessionCommands({
+      provider,
+      instanceStore,
+      instanceController: undefined,
+      instanceQuickPick: undefined,
+      outputChannel: undefined,
+      tmuxManager,
+      zellijManager,
+    });
+
+    await getCommandHandlers().browseTmuxSessions();
+
+    expect(tmuxManager.discoverSessions).not.toHaveBeenCalled();
+    expect(zellijManager.discoverSessions).toHaveBeenCalledTimes(1);
+    expect(provider.switchToZellijSession).toHaveBeenCalledWith("zellij-b");
+    expect(provider.switchToTmuxSession).not.toHaveBeenCalled();
   });
 
   it("logs and shows errors when browsing tmux sessions fails", async () => {

--- a/src/core/commands/tmuxSessionCommands.ts
+++ b/src/core/commands/tmuxSessionCommands.ts
@@ -5,6 +5,8 @@ import type { InstanceQuickPick } from "../../services/InstanceQuickPick";
 import type { InstanceStore } from "../../services/InstanceStore";
 import type { OutputChannelService } from "../../services/OutputChannelService";
 import type { TmuxSessionManager } from "../../services/TmuxSessionManager";
+import type { ZellijSessionManager } from "../../services/ZellijSessionManager";
+import type { TerminalBackendType } from "../../types";
 
 export interface TmuxSessionCommandDependencies {
   provider: TerminalProvider | undefined;
@@ -13,6 +15,17 @@ export interface TmuxSessionCommandDependencies {
   instanceQuickPick: InstanceQuickPick | undefined;
   outputChannel: OutputChannelService | undefined;
   tmuxManager: TmuxSessionManager | undefined;
+  zellijManager?: ZellijSessionManager | undefined;
+}
+
+function getActiveBackend(
+  instanceStore: InstanceStore | undefined,
+): TerminalBackendType {
+  try {
+    return instanceStore?.getActive().runtime.terminalBackend ?? "tmux";
+  } catch {
+    return "tmux";
+  }
 }
 
 export function registerTmuxSessionCommands(
@@ -196,22 +209,29 @@ export function registerTmuxSessionCommands(
   const browseTmuxSessionsCommand = vscode.commands.registerCommand(
     "opencodeTui.browseTmuxSessions",
     async () => {
-      if (!deps.tmuxManager || !deps.provider) {
+      const activeBackend = getActiveBackend(deps.instanceStore);
+      const sessionManager =
+        activeBackend === "zellij" ? deps.zellijManager : deps.tmuxManager;
+      const backendLabel = activeBackend === "zellij" ? "zellij" : "tmux";
+
+      if (!sessionManager || !deps.provider) {
         vscode.window.showWarningMessage(
-          "tmux is not available or the terminal provider is not initialized",
+          `${backendLabel} is not available or the terminal provider is not initialized`,
         );
         return;
       }
 
       try {
-        const sessions = await deps.tmuxManager.discoverSessions();
+        const sessions = await sessionManager.discoverSessions();
         if (sessions.length === 0) {
-          vscode.window.showInformationMessage("No tmux sessions found");
+          vscode.window.showInformationMessage(`No ${backendLabel} sessions found`);
           return;
         }
 
         const activeSessionId =
-          deps.instanceStore?.getActive()?.runtime.tmuxSessionId;
+          activeBackend === "zellij"
+            ? deps.instanceStore?.getActive()?.runtime.zellijSessionId
+            : deps.instanceStore?.getActive()?.runtime.tmuxSessionId;
 
         const items = sessions.map((session) => ({
           label: session.name,
@@ -229,7 +249,7 @@ export function registerTmuxSessionCommands(
         const picked = await vscode.window.showQuickPick(items, {
           placeHolder: activeSessionId
             ? `Current: ${activeSessionId} — select a session to switch`
-            : "Select a tmux session to attach",
+            : `Select a ${backendLabel} session to attach`,
           matchOnDescription: true,
           matchOnDetail: true,
         });
@@ -245,7 +265,11 @@ export function registerTmuxSessionCommands(
           return;
         }
 
-        await deps.provider.switchToTmuxSession(picked.session.id);
+        if (activeBackend === "zellij") {
+          await deps.provider.switchToZellijSession(picked.session.id);
+        } else {
+          await deps.provider.switchToTmuxSession(picked.session.id);
+        }
         await vscode.commands.executeCommand("opencodeTui.focus");
       } catch (error) {
         deps.outputChannel?.error(

--- a/src/providers/MessageRouter.test.ts
+++ b/src/providers/MessageRouter.test.ts
@@ -75,6 +75,8 @@ describe("MessageRouter", () => {
       toggleEditorAttachment: vi.fn(async () => undefined),
       restart: vi.fn(),
       switchToNativeShell: vi.fn(async () => undefined),
+      selectTerminalBackend: vi.fn(async () => undefined),
+      cycleTerminalBackend: vi.fn(async () => undefined),
       pasteText: vi.fn(),
       getActiveInstanceId: vi.fn(() => "instance-1"),
       getActiveTerminalId: vi.fn(() => "terminal-1"),
@@ -95,6 +97,13 @@ describe("MessageRouter", () => {
       zoomTmuxPane: vi.fn(async () => undefined),
       getSelectedTmuxSessionId: vi.fn(() => "tmux-selected"),
       isTmuxAvailable: vi.fn(() => true),
+      isZellijAvailable: vi.fn(() => true),
+      getActiveBackend: () => "tmux",
+      getBackendAvailability: vi.fn(() => ({
+        native: true,
+        tmux: true,
+        zellij: true,
+      })),
     };
   }
 
@@ -213,6 +222,9 @@ describe("MessageRouter", () => {
       type: "platformInfo",
       platform: process.platform,
       tmuxAvailable: true,
+      zellijAvailable: true,
+      backendAvailability: { native: true, tmux: true, zellij: true },
+      activeBackend: "tmux",
     });
   });
 
@@ -243,6 +255,11 @@ describe("MessageRouter", () => {
       type: "sendTmuxPromptChoice",
       choice: "shell",
     });
+    await router.handleMessage({
+      type: "sendTmuxPromptChoice",
+      choice: "zellij",
+    });
+    await router.handleMessage({ type: "cycleTerminalBackend" });
     await router.handleMessage({ type: "requestAiToolSelector" });
     await router.handleMessage({
       type: "executeTmuxCommand",
@@ -262,7 +279,10 @@ describe("MessageRouter", () => {
     expect(provider.pasteText).toHaveBeenCalledWith("clipboard text");
     expect(provider.switchToTmuxSession).toHaveBeenCalledWith("tmux-a");
     expect(provider.killTmuxSession).toHaveBeenCalledWith("tmux-b");
-    expect(provider.createTmuxSession).toHaveBeenCalledTimes(2);
+    expect(provider.createTmuxSession).toHaveBeenCalledTimes(1);
+    expect(provider.selectTerminalBackend).toHaveBeenCalledWith("tmux");
+    expect(provider.selectTerminalBackend).toHaveBeenCalledWith("zellij");
+    expect(provider.cycleTerminalBackend).toHaveBeenCalledTimes(1);
     expect(provider.switchToNativeShell).toHaveBeenCalledTimes(1);
     expect(provider.launchAiTool).toHaveBeenCalledWith(
       "tmux-c",
@@ -680,6 +700,9 @@ describe("MessageRouter", () => {
       type: "platformInfo",
       platform: process.platform,
       tmuxAvailable: true,
+      zellijAvailable: true,
+      backendAvailability: { native: true, tmux: true, zellij: true },
+      activeBackend: "tmux",
     });
   });
 

--- a/src/providers/MessageRouter.test.ts
+++ b/src/providers/MessageRouter.test.ts
@@ -77,6 +77,7 @@ describe("MessageRouter", () => {
       switchToNativeShell: vi.fn(async () => undefined),
       pasteText: vi.fn(),
       getActiveInstanceId: vi.fn(() => "instance-1"),
+      getActiveTerminalId: vi.fn(() => "terminal-1"),
       setLastKnownTerminalSize: vi.fn(),
       getLastKnownTerminalSize: vi.fn(() => ({ cols: 120, rows: 40 })),
       isStarted: vi.fn(() => false),
@@ -198,12 +199,12 @@ describe("MessageRouter", () => {
     await router.handleMessage({ type: "ready", cols: 80, rows: 25 });
 
     expect(terminalManager.writeToTerminal).toHaveBeenCalledWith(
-      "instance-1",
+      "terminal-1",
       "pwd\n",
     );
     expect(provider.setLastKnownTerminalSize).toHaveBeenCalledWith(100, 30);
     expect(terminalManager.resizeTerminal).toHaveBeenCalledWith(
-      "instance-1",
+      "terminal-1",
       100,
       30,
     );

--- a/src/providers/MessageRouter.test.ts
+++ b/src/providers/MessageRouter.test.ts
@@ -6,6 +6,7 @@ import { MessageRouter } from "./MessageRouter";
 import { OutputChannelService } from "../services/OutputChannelService";
 import type { TerminalManager } from "../terminals/TerminalManager";
 import type { OutputCaptureManager } from "../services/OutputCaptureManager";
+import type { TerminalBackendType } from "../types";
 
 const mockWriteFile = vi.hoisted(() => vi.fn(async () => undefined));
 const mockUnlink = vi.hoisted(() => vi.fn(async () => undefined));
@@ -69,6 +70,7 @@ describe("MessageRouter", () => {
     return {
       startOpenCode: vi.fn(async () => undefined),
       switchToTmuxSession: vi.fn(async () => undefined),
+      switchToZellijSession: vi.fn(async () => undefined),
       killTmuxSession: vi.fn(async () => undefined),
       createTmuxSession: vi.fn(async () => "tmux-new"),
       toggleDashboard: vi.fn(),
@@ -98,7 +100,7 @@ describe("MessageRouter", () => {
       getSelectedTmuxSessionId: vi.fn(() => "tmux-selected"),
       isTmuxAvailable: vi.fn(() => true),
       isZellijAvailable: vi.fn(() => true),
-      getActiveBackend: () => "tmux",
+      getActiveBackend: vi.fn<() => TerminalBackendType>(() => "tmux"),
       getBackendAvailability: vi.fn(() => ({
         native: true,
         tmux: true,
@@ -301,6 +303,31 @@ describe("MessageRouter", () => {
     expect(provider.toggleDashboard).toHaveBeenCalledTimes(1);
     expect(provider.toggleEditorAttachment).toHaveBeenCalledTimes(1);
     expect(vscode.window.showTextDocument).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes switchSession through zellij when zellij backend is active", async () => {
+    provider.getActiveBackend = vi.fn<() => TerminalBackendType>(() => "zellij");
+
+    await router.handleMessage({ type: "switchSession", sessionId: "zellij-a" });
+
+    expect(provider.switchToZellijSession).toHaveBeenCalledWith("zellij-a");
+    expect(provider.switchToTmuxSession).not.toHaveBeenCalled();
+  });
+
+  it("routes killSession through the backend-aware session runtime bridge for zellij", async () => {
+    provider.getActiveBackend = vi.fn<() => TerminalBackendType>(() => "zellij");
+
+    await router.handleMessage({ type: "killSession", sessionId: "zellij-b" });
+
+    expect(provider.killTmuxSession).toHaveBeenCalledWith("zellij-b");
+  });
+
+  it("routes zoomTmuxPane through the backend-aware session runtime bridge for zellij", async () => {
+    provider.getActiveBackend = vi.fn<() => TerminalBackendType>(() => "zellij");
+
+    await router.handleMessage({ type: "zoomTmuxPane" });
+
+    expect(provider.zoomTmuxPane).toHaveBeenCalledTimes(1);
   });
 
   it("routes filesDropped with shift and pane fallback or direct terminal writes", async () => {

--- a/src/providers/MessageRouter.ts
+++ b/src/providers/MessageRouter.ts
@@ -31,6 +31,7 @@ export interface MessageRouterProviderBridge {
   switchToNativeShell(): Promise<void>;
   pasteText(text: string): void;
   getActiveInstanceId(): InstanceId;
+  getActiveTerminalId(): string;
   setLastKnownTerminalSize(cols: number, rows: number): void;
   getLastKnownTerminalSize(): { cols: number; rows: number };
   isStarted(): boolean;
@@ -200,7 +201,7 @@ export class MessageRouter {
     }
 
     this.terminalManager.writeToTerminal(
-      this.provider.getActiveInstanceId(),
+      this.provider.getActiveTerminalId(),
       data,
     );
   }
@@ -272,7 +273,7 @@ export class MessageRouter {
 
     this.provider.setLastKnownTerminalSize(cols, rows);
     this.terminalManager.resizeTerminal(
-      this.provider.getActiveInstanceId(),
+      this.provider.getActiveTerminalId(),
       cols,
       rows,
     );

--- a/src/providers/MessageRouter.ts
+++ b/src/providers/MessageRouter.ts
@@ -17,7 +17,11 @@ import {
   TMUX_WEBVIEW_COMMAND_IDS,
   WebviewMessage,
 } from "../types";
-import type { TmuxRawSubcommand, TmuxWebviewCommandId } from "../types";
+import type {
+  TerminalBackendType,
+  TmuxRawSubcommand,
+  TmuxWebviewCommandId,
+} from "../types";
 import { isWindowsAbsolutePath } from "../utils/pathUtils";
 
 export interface MessageRouterProviderBridge {
@@ -29,6 +33,8 @@ export interface MessageRouterProviderBridge {
   toggleEditorAttachment(): Promise<void>;
   restart(): void;
   switchToNativeShell(): Promise<void>;
+  selectTerminalBackend(backend: TerminalBackendType): Promise<void>;
+  cycleTerminalBackend(): Promise<void>;
   pasteText(text: string): void;
   getActiveInstanceId(): InstanceId;
   getActiveTerminalId(): string;
@@ -59,6 +65,13 @@ export interface MessageRouterProviderBridge {
   zoomTmuxPane(): Promise<void>;
   getSelectedTmuxSessionId(): string | undefined;
   isTmuxAvailable(): boolean;
+  isZellijAvailable(): boolean;
+  getActiveBackend(): TerminalBackendType;
+  getBackendAvailability(): {
+    native: boolean;
+    tmux: boolean;
+    zellij: boolean;
+  };
 }
 
 export class MessageRouter {
@@ -160,10 +173,18 @@ export class MessageRouter {
         break;
       case "sendTmuxPromptChoice":
         if (message.choice === "tmux") {
-          void this.provider.createTmuxSession();
+          void this.provider.selectTerminalBackend("tmux");
         } else if (message.choice === "shell") {
           void this.provider.switchToNativeShell();
+        } else if (message.choice === "zellij") {
+          void this.provider.selectTerminalBackend("zellij");
         }
+        break;
+      case "selectTerminalBackend":
+        void this.provider.selectTerminalBackend(message.backend);
+        break;
+      case "cycleTerminalBackend":
+        void this.provider.cycleTerminalBackend();
         break;
       case "requestAiToolSelector": {
         const sessionId =
@@ -297,6 +318,9 @@ export class MessageRouter {
       type: "platformInfo",
       platform: process.platform,
       tmuxAvailable: this.provider.isTmuxAvailable(),
+      zellijAvailable: this.provider.isZellijAvailable(),
+      backendAvailability: this.provider.getBackendAvailability(),
+      activeBackend: this.provider.getActiveBackend(),
     });
   }
 

--- a/src/providers/MessageRouter.ts
+++ b/src/providers/MessageRouter.ts
@@ -27,6 +27,7 @@ import { isWindowsAbsolutePath } from "../utils/pathUtils";
 export interface MessageRouterProviderBridge {
   startOpenCode(): Promise<void>;
   switchToTmuxSession(sessionId: string): Promise<void>;
+  switchToZellijSession(sessionId: string): Promise<void>;
   killTmuxSession(sessionId: string): Promise<void>;
   createTmuxSession(): Promise<string | undefined>;
   toggleDashboard(): void;
@@ -143,7 +144,11 @@ export class MessageRouter {
         break;
       case "switchSession":
         if (typeof message.sessionId === "string") {
-          void this.provider.switchToTmuxSession(message.sessionId);
+          if (this.provider.getActiveBackend() === "zellij") {
+            void this.provider.switchToZellijSession(message.sessionId);
+          } else {
+            void this.provider.switchToTmuxSession(message.sessionId);
+          }
         }
         break;
       case "killSession":
@@ -152,7 +157,11 @@ export class MessageRouter {
         }
         break;
       case "createTmuxSession":
-        void this.provider.createTmuxSession();
+        if (this.provider.getActiveBackend() === "zellij") {
+          void this.provider.selectTerminalBackend("zellij");
+        } else {
+          void this.provider.createTmuxSession();
+        }
         break;
       case "launchAiTool":
         void this.provider.launchAiTool(
@@ -254,6 +263,13 @@ export class MessageRouter {
     }
 
     try {
+      if (this.provider.getActiveBackend() === "zellij") {
+        this.logger.warn(
+          `[MessageRouter] executeTmuxRawCommand ignored for zellij backend: ${subcommand}`,
+        );
+        return;
+      }
+
       await this.provider.executeRawTmuxCommand(subcommand, args);
     } catch (error) {
       this.logger.error(

--- a/src/providers/SessionRuntime.test.ts
+++ b/src/providers/SessionRuntime.test.ts
@@ -14,6 +14,12 @@ import {
   TmuxUnavailableError,
 } from "../services/TmuxSessionManager";
 import { AiToolOperatorRegistry } from "../services/aiTools/AiToolOperatorRegistry";
+import { ZellijSessionManager } from "../services/ZellijSessionManager";
+import {
+  StaticTerminalBackend,
+  TerminalBackendRegistry,
+} from "../services/terminalBackends";
+import type { TerminalBackendType } from "../types";
 
 const vscode = await vi.importActual<typeof vscodeTypes>(
   "../test/mocks/vscode",
@@ -37,6 +43,8 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
 
   let sessionRuntime: SessionRuntime;
   let mockTmuxSessionManager: TmuxSessionManager;
+  let mockZellijSessionManager: ZellijSessionManager;
+  let backendRegistry: TerminalBackendRegistry;
   let mockTerminalManager: TerminalManager;
   let mockPortManager: PortManager;
   let mockAiToolRegistry: AiToolOperatorRegistry;
@@ -67,9 +75,20 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
     ) => void;
   };
 
+  const setConfiguration = (values: Record<string, unknown> = {}): void => {
+    vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+      get: vi.fn(<T>(key: string, defaultValue?: T): T => {
+        return key in values ? (values[key] as T) : (defaultValue as T);
+      }),
+      inspect: vi.fn(() => undefined),
+      update: vi.fn(async () => undefined),
+    } as ReturnType<typeof vscode.workspace.getConfiguration>);
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     OutputChannelService.resetInstance();
+    setConfiguration();
 
     // Setup workspace folders
     vscode.workspace.workspaceFolders = [
@@ -107,6 +126,22 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       findSessionForWorkspace: vi.fn(),
       getSessionInfo: vi.fn(),
     } as unknown as TmuxSessionManager;
+
+    mockZellijSessionManager = {
+      discoverSessions: vi.fn(),
+      ensureSession: vi.fn(),
+      createSession: vi.fn(),
+      getAttachCommand: vi.fn((sessionName: string) =>
+        `zellij attach '${sessionName}'`,
+      ),
+      isAvailable: vi.fn(async () => true),
+    } as unknown as ZellijSessionManager;
+
+    backendRegistry = new TerminalBackendRegistry([
+      new StaticTerminalBackend("native", "Native", true),
+      new StaticTerminalBackend("tmux", "Tmux", true),
+      new StaticTerminalBackend("zellij", "Zellij", true),
+    ]);
 
     mockTerminalManager = {
       getByInstance: vi.fn(),
@@ -171,6 +206,8 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       undefined as unknown as OpenCodeApiClient,
       mockPortManager,
       mockTmuxSessionManager,
+      mockZellijSessionManager,
+      backendRegistry,
       instanceStore,
       mockLogger,
       mockContextSharingService,
@@ -190,6 +227,7 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
     id?: string;
     workspaceUri?: string;
     tmuxSessionId?: string;
+    zellijSessionId?: string;
     selectedAiTool?: string;
   }) => {
     const id = options?.id ?? "default";
@@ -202,6 +240,7 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       runtime: {
         terminalKey: id,
         tmuxSessionId: options?.tmuxSessionId,
+        zellijSessionId: options?.zellijSessionId,
       },
       state: "connected",
     });
@@ -396,6 +435,7 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
         type: "activeSession",
         sessionName: "project-a",
         sessionId: "project-a",
+        backend: "tmux",
       });
     });
 
@@ -420,6 +460,7 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       });
       expect(postMessageMock).toHaveBeenCalledWith({
         type: "activeSession",
+        backend: "native",
       });
     });
   });
@@ -442,6 +483,13 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       expect(
         sessionRuntime.resolveInstanceIdFromSessionId("tmux-session"),
       ).toBe("tmux-instance");
+      upsertInstance({
+        id: "zellij-instance",
+        zellijSessionId: "zellij-session",
+      });
+      expect(
+        sessionRuntime.resolveInstanceIdFromSessionId("zellij-session"),
+      ).toBe("zellij-instance");
       expect(sessionRuntime.resolveInstanceIdFromSessionId("project-a")).toBe(
         "workspace-instance",
       );
@@ -467,6 +515,8 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
         undefined as unknown as OpenCodeApiClient,
         mockPortManager,
         mockTmuxSessionManager,
+        mockZellijSessionManager,
+        backendRegistry,
         undefined,
         mockLogger,
         {} as ContextSharingService,
@@ -483,6 +533,117 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
   });
 
   describe("instance switching and startup", () => {
+    it("switches to a zellij backend session", async () => {
+      upsertInstance({ workspaceUri: "file:///workspace/project-a" });
+      vi.mocked(mockZellijSessionManager.ensureSession).mockResolvedValue({
+        action: "created",
+        session: {
+          id: "project-a",
+          name: "project-a",
+          workspace: "project-a",
+          isActive: true,
+        },
+      });
+
+      await sessionRuntime.selectTerminalBackend("zellij");
+
+      expect(mockZellijSessionManager.ensureSession).toHaveBeenCalledWith(
+        "project-a",
+        "/workspace/project-a",
+      );
+      expect(requestStartOpenCodeMock).toHaveBeenCalled();
+      expect(sessionRuntime.getActiveBackend()).toBe("zellij");
+    });
+
+    it("keeps explicit zellij selection when JSON config defaults to tmux", async () => {
+      setConfiguration({ terminalBackend: "tmux" satisfies TerminalBackendType });
+      upsertInstance({ workspaceUri: "file:///workspace/project-a" });
+      vi.mocked(mockZellijSessionManager.ensureSession).mockResolvedValue({
+        action: "created",
+        session: {
+          id: "project-a",
+          name: "project-a",
+          workspace: "project-a",
+          isActive: true,
+        },
+      });
+      vi.spyOn(
+        sessionRuntime as unknown as {
+          resolveToolForStartup: () => Promise<{ name: string }>;
+        },
+        "resolveToolForStartup",
+      ).mockResolvedValue({ name: "preferred-tool" });
+      vi.mocked(mockAiToolRegistry.getForConfig).mockReturnValue({
+        getLaunchCommand: vi.fn(() => "run-tool"),
+        supportsHttpApi: vi.fn(() => false),
+      } as never);
+
+      await sessionRuntime.selectTerminalBackend("zellij");
+      requestStartOpenCodeMock.mockClear();
+
+      await sessionRuntime.startOpenCode();
+
+      expect(mockTerminalManager.createTerminal).toHaveBeenCalledWith(
+        "default",
+        "zellij attach 'project-a'",
+        {},
+        undefined,
+        undefined,
+        undefined,
+        "default",
+        "/workspace/project-a",
+      );
+      expect(instanceStore.get("default")?.runtime.terminalBackend).toBe(
+        "zellij",
+      );
+      expect(instanceStore.get("default")?.runtime.zellijSessionId).toBe(
+        "project-a",
+      );
+    });
+
+    it("keeps explicit tmux session selection when JSON config defaults to zellij", async () => {
+      setConfiguration({ terminalBackend: "zellij" satisfies TerminalBackendType });
+      upsertInstance({ workspaceUri: "file:///workspace/project-a" });
+      vi.spyOn(
+        sessionRuntime as unknown as {
+          resolveToolForStartup: () => Promise<{ name: string }>;
+        },
+        "resolveToolForStartup",
+      ).mockResolvedValue({ name: "preferred-tool" });
+      vi.spyOn(
+        sessionRuntime as unknown as {
+          startExternalChangeMonitoring: (sessionId: string) => Promise<void>;
+        },
+        "startExternalChangeMonitoring",
+      ).mockResolvedValue();
+      vi.mocked(mockAiToolRegistry.getForConfig).mockReturnValue({
+        getLaunchCommand: vi.fn(() => "run-tool"),
+        supportsHttpApi: vi.fn(() => false),
+      } as never);
+
+      await sessionRuntime.switchToTmuxSession("manual-tmux");
+      requestStartOpenCodeMock.mockClear();
+
+      await sessionRuntime.startOpenCode();
+
+      expect(mockTerminalManager.createTerminal).toHaveBeenCalledWith(
+        "default",
+        "tmux attach-session -t manual-tmux \\; set-option -u status off",
+        {},
+        undefined,
+        undefined,
+        undefined,
+        "default",
+        "/workspace/project-a",
+      );
+      expect(instanceStore.get("default")?.runtime.terminalBackend).toBe(
+        "tmux",
+      );
+      expect(instanceStore.get("default")?.runtime.tmuxSessionId).toBe(
+        "manual-tmux",
+      );
+    });
+
     it("reuses an existing terminal for an instance and restores HTTP listeners", async () => {
       upsertInstance({ id: "instance-2", selectedAiTool: "preferred-tool" });
       sessionRuntime.setLastKnownTerminalSize(120, 40);
@@ -576,7 +737,10 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
         "/workspace/project-a",
       );
       expect(sessionRuntime.isStartedFlag()).toBe(true);
-      expect(postMessageMock).toHaveBeenCalledWith({ type: "activeSession" });
+      expect(postMessageMock).toHaveBeenCalledWith({
+        type: "activeSession",
+        backend: "native",
+      });
       expect(
         instanceStore.get("default")?.runtime.tmuxSessionId,
       ).toBeUndefined();
@@ -593,6 +757,12 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
         undefined as unknown as OpenCodeApiClient,
         mockPortManager,
         undefined,
+        undefined,
+        new TerminalBackendRegistry([
+          new StaticTerminalBackend("native", "Native", true),
+          new StaticTerminalBackend("tmux", "Tmux", false),
+          new StaticTerminalBackend("zellij", "Zellij", false),
+        ]),
         instanceStore,
         mockLogger,
         mockContextSharingService,
@@ -691,6 +861,7 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
         type: "activeSession",
         sessionName: "workspace-session",
         sessionId: "workspace-session",
+        backend: "tmux",
       });
     });
   });

--- a/src/providers/SessionRuntime.test.ts
+++ b/src/providers/SessionRuntime.test.ts
@@ -522,6 +522,21 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       expect(sessionRuntime.getApiClient()).toBeDefined();
     });
 
+    it("resolves active terminal backend ids from non-tmux runtime terminal keys", async () => {
+      instanceStore.upsert({
+        config: { id: "native-instance" },
+        runtime: { terminalKey: "native-terminal-key" },
+        state: "connected",
+      });
+      instanceStore.setActive("native-instance");
+      (
+        sessionRuntime as unknown as { activeInstanceId: string }
+      ).activeInstanceId = "native-instance";
+
+      expect(sessionRuntime.getActiveInstanceId()).toBe("native-instance");
+      expect(sessionRuntime.getActiveTerminalId()).toBe("native-terminal-key");
+    });
+
     it("force restarts an existing instance by killing its terminal and requesting a relaunch", async () => {
       upsertInstance({ id: "instance-2" });
       vi.mocked(mockTerminalManager.getByInstance).mockReturnValue({

--- a/src/providers/SessionRuntime.test.ts
+++ b/src/providers/SessionRuntime.test.ts
@@ -90,7 +90,6 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
     OutputChannelService.resetInstance();
     setConfiguration();
 
-    // Setup workspace folders
     vscode.workspace.workspaceFolders = [
       {
         uri: { fsPath: "/workspace/project-a" },
@@ -99,7 +98,6 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       },
     ];
 
-    // Create mock tmux session manager with all required methods
     mockTmuxSessionManager = {
       listPanes: vi.fn(),
       listWindows: vi.fn(),
@@ -178,16 +176,13 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       getCurrentContext: vi.fn(),
     } as unknown as ContextSharingService;
 
-    // Create real instance store (following pattern from TerminalProvider.test.ts)
     instanceStore = new InstanceStore();
 
-    // Create mock logger
     mockLogger = OutputChannelService.getInstance();
     vi.spyOn(mockLogger, "warn");
     vi.spyOn(mockLogger, "error");
     vi.spyOn(mockLogger, "info");
 
-    // Create mock callbacks
     postMessageMock = vi.fn();
     onActiveInstanceChangedMock = vi.fn();
     requestStartOpenCodeMock = vi.fn().mockResolvedValue(undefined);
@@ -205,7 +200,6 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       },
     };
 
-    // Create SessionRuntime instance with proper typing
     sessionRuntime = new SessionRuntime(
       mockTerminalManager,
       {} as OutputCaptureManager,

--- a/src/providers/SessionRuntime.test.ts
+++ b/src/providers/SessionRuntime.test.ts
@@ -131,6 +131,12 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       discoverSessions: vi.fn(),
       ensureSession: vi.fn(),
       createSession: vi.fn(),
+      killSession: vi.fn(),
+      switchSession: vi.fn(),
+      zoomPane: vi.fn(),
+      sendTextToPane: vi.fn(),
+      listPanes: vi.fn(),
+      listTabs: vi.fn(),
       getAttachCommand: vi.fn((sessionName: string) =>
         `zellij attach '${sessionName}'`,
       ),
@@ -247,8 +253,14 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
     return id;
   };
 
+  const setActiveBackend = (backend: TerminalBackendType): void => {
+    (sessionRuntime as unknown as { activeBackend: TerminalBackendType }).activeBackend =
+      backend;
+  };
+
   describe("checkPaneChanges", () => {
     it("falls back to discovered sessions and posts active session metadata", async () => {
+      setActiveBackend("tmux");
       vi.mocked(mockTmuxSessionManager.discoverSessions).mockResolvedValue([
         { id: "fallback-session", isActive: true },
       ] as unknown as Awaited<
@@ -282,6 +294,7 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
     });
 
     it("posts updates when window focus changes", async () => {
+      setActiveBackend("tmux");
       upsertInstance({ tmuxSessionId: "workspace-session" });
       (
         sessionRuntime as unknown as { knownActiveWindowId?: string }
@@ -311,6 +324,7 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
     });
 
     it("silently ignores tmux polling errors", async () => {
+      setActiveBackend("tmux");
       upsertInstance({ tmuxSessionId: "workspace-session" });
       vi.mocked(mockTmuxSessionManager.listPanes).mockRejectedValue(
         new Error("tmux unavailable"),
@@ -322,6 +336,56 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
         ).checkPaneChanges(),
       ).resolves.toBeUndefined();
       expect(postMessageMock).not.toHaveBeenCalled();
+    });
+
+    it("routes zellij polling through panes and tabs", async () => {
+      setActiveBackend("zellij");
+      upsertInstance({ zellijSessionId: "zellij-session" });
+
+      vi.mocked(mockZellijSessionManager.listPanes).mockResolvedValue([
+        { id: "terminal_1", title: "shell", isFocused: true, isFloating: false },
+        { id: "terminal_2", title: "agent", isFocused: false, isFloating: false },
+      ] as Awaited<ReturnType<ZellijSessionManager["listPanes"]>>);
+      vi.mocked(mockZellijSessionManager.listTabs).mockResolvedValue([
+        { index: 1, name: "main", isActive: true },
+      ] as Awaited<ReturnType<ZellijSessionManager["listTabs"]>>);
+
+      await (
+        sessionRuntime as unknown as { checkPaneChanges: () => Promise<void> }
+      ).checkPaneChanges();
+
+      expect(mockZellijSessionManager.listPanes).toHaveBeenCalled();
+      expect(mockZellijSessionManager.listTabs).toHaveBeenCalled();
+      expect(mockTmuxSessionManager.listPanes).not.toHaveBeenCalled();
+      expect(postMessageMock).toHaveBeenCalledWith({
+        type: "activeSession",
+        sessionName: "zellij-session",
+        sessionId: "zellij-session",
+        windowIndex: 1,
+        windowName: "main",
+        canKillPane: true,
+      });
+    });
+
+    it("starts zellij change monitoring with polling only", async () => {
+      setActiveBackend("zellij");
+      vi.mocked(mockZellijSessionManager.listPanes).mockResolvedValue([
+        { id: "terminal_1", title: "shell", isFocused: true, isFloating: false },
+      ] as Awaited<ReturnType<ZellijSessionManager["listPanes"]>>);
+
+      await (
+        sessionRuntime as unknown as {
+          startExternalChangeMonitoring: (sessionId: string) => Promise<void>;
+        }
+      ).startExternalChangeMonitoring("zellij-session");
+
+      expect(mockZellijSessionManager.listPanes).toHaveBeenCalled();
+      expect(mockTmuxSessionManager.listPanes).not.toHaveBeenCalled();
+      expect(mockTmuxSessionManager.onExternalPaneChange).not.toHaveBeenCalled();
+      expect(
+        (sessionRuntime as unknown as { paneMonitorInterval?: unknown })
+          .paneMonitorInterval,
+      ).toBeDefined();
     });
   });
 
@@ -1055,6 +1119,7 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
     });
 
     it("zooms the active pane", async () => {
+      setActiveBackend("tmux");
       upsertInstance({
         tmuxSessionId: "workspace-session",
         workspaceUri: "file:///workspace/project-a",
@@ -1078,7 +1143,18 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       expect(mockTmuxSessionManager.zoomPane).toHaveBeenCalledWith("%2");
     });
 
+    it("zooms the focused zellij pane without tmux pane lookup", async () => {
+      setActiveBackend("zellij");
+
+      await sessionRuntime.zoomTmuxPane();
+
+      expect(mockZellijSessionManager.zoomPane).toHaveBeenCalled();
+      expect(mockTmuxSessionManager.listPanes).not.toHaveBeenCalled();
+      expect(mockTmuxSessionManager.zoomPane).not.toHaveBeenCalled();
+    });
+
     it("kills tmux sessions and switches to a replacement workspace session when available", async () => {
+      setActiveBackend("tmux");
       upsertInstance({
         tmuxSessionId: "workspace-session",
         workspaceUri: "file:///workspace/project-a",
@@ -1113,6 +1189,7 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
     });
 
     it("falls back to native shell after killing the active tmux session when no replacement exists", async () => {
+      setActiveBackend("tmux");
       upsertInstance({
         tmuxSessionId: "workspace-session",
         workspaceUri: "file:///workspace/project-a",
@@ -1127,10 +1204,35 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
 
       expect(nativeShellSpy).toHaveBeenCalled();
     });
+
+    it("kills zellij sessions through the zellij manager", async () => {
+      setActiveBackend("zellij");
+      upsertInstance({ zellijSessionId: "zellij-session" });
+      (sessionRuntime as unknown as { isStarted: boolean }).isStarted = true;
+
+      const nativeShellSpy = vi
+        .spyOn(sessionRuntime, "switchToNativeShell")
+        .mockResolvedValue();
+
+      await sessionRuntime.killTmuxSession("zellij-session");
+
+      expect(mockZellijSessionManager.killSession).toHaveBeenCalledWith(
+        "zellij-session",
+      );
+      expect(mockTmuxSessionManager.killSession).not.toHaveBeenCalled();
+      expect(
+        instanceStore.get("default")?.runtime.zellijSessionId,
+      ).toBeUndefined();
+      expect(mockPortManager.releaseTerminalPorts).toHaveBeenCalledWith(
+        "default",
+      );
+      expect(nativeShellSpy).toHaveBeenCalled();
+    });
   });
 
   describe("pane routing and formatting helpers", () => {
     it("routes dropped text into the pane under the drop coordinates", async () => {
+      setActiveBackend("tmux");
       upsertInstance({
         tmuxSessionId: "workspace-session",
         workspaceUri: "file:///workspace/project-a",
@@ -1178,6 +1280,7 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
     });
 
     it("returns false when dropped text does not intersect any pane", async () => {
+      setActiveBackend("tmux");
       upsertInstance({ tmuxSessionId: "workspace-session" });
       vi.mocked(
         mockTmuxSessionManager.listVisiblePaneGeometry,

--- a/src/providers/SessionRuntime.ts
+++ b/src/providers/SessionRuntime.ts
@@ -84,6 +84,10 @@ export class SessionRuntime {
     return this.activeInstanceId;
   }
 
+  public getActiveTerminalId(): string {
+    return this.resolveTerminalIdForInstance(this.activeInstanceId);
+  }
+
   public getLastKnownTerminalSize(): { cols: number; rows: number } {
     return { cols: this.lastKnownCols, rows: this.lastKnownRows };
   }
@@ -130,7 +134,7 @@ export class SessionRuntime {
   public hasLiveTerminalProcess(): boolean {
     return (
       this.isStarted &&
-      this.terminalManager.getTerminal(this.activeInstanceId) !== undefined
+      this.terminalManager.getTerminal(this.getActiveTerminalId()) !== undefined
     );
   }
 
@@ -184,7 +188,7 @@ export class SessionRuntime {
 
       if (this.lastKnownCols && this.lastKnownRows) {
         this.terminalManager.resizeTerminal(
-          this.activeInstanceId,
+          this.getActiveTerminalId(),
           this.lastKnownCols,
           this.lastKnownRows,
         );
@@ -384,7 +388,7 @@ export class SessionRuntime {
 
   public restart(): void {
     this.disposeListeners();
-    this.terminalManager.killTerminal(this.activeInstanceId);
+    this.terminalManager.killTerminal(this.getActiveTerminalId());
     this.resetState();
 
     this.callbacks.postMessage({ type: "clearTerminal" });
@@ -1166,7 +1170,21 @@ export class SessionRuntime {
     this.activeInstanceSubscription?.dispose();
     this.activeInstanceSubscription = undefined;
     if (this.isStarted) {
-      this.terminalManager.killTerminal(this.activeInstanceId);
+      this.terminalManager.killTerminal(this.getActiveTerminalId());
+    }
+  }
+
+  private resolveTerminalIdForInstance(instanceId: InstanceId): string {
+    if (!this.instanceStore) {
+      return instanceId;
+    }
+
+    try {
+      return (
+        this.instanceStore.get(instanceId)?.runtime.terminalKey ?? instanceId
+      );
+    } catch {
+      return instanceId;
     }
   }
 

--- a/src/providers/SessionRuntime.ts
+++ b/src/providers/SessionRuntime.ts
@@ -162,6 +162,9 @@ export class SessionRuntime {
         await this.switchToTmuxSession(sessionId);
         return;
       }
+      void vscode.window.showWarningMessage(
+        "Tmux session could not be created. Falling back to native shell.",
+      );
       await this.switchToNativeShell();
       return;
     }
@@ -170,6 +173,9 @@ export class SessionRuntime {
       await this.switchToZellijSession(sessionId);
       return;
     }
+    void vscode.window.showWarningMessage(
+      "Zellij session could not be created. Falling back to native shell.",
+    );
     await this.switchToNativeShell();
   }
 

--- a/src/providers/SessionRuntime.ts
+++ b/src/providers/SessionRuntime.ts
@@ -7,7 +7,11 @@ import { PortManager } from "../services/PortManager";
 import { ContextSharingService } from "../services/ContextSharingService";
 import { OutputChannelService } from "../services/OutputChannelService";
 import { InstanceId, InstanceStore } from "../services/InstanceStore";
-import { AiToolConfig, resolveAiToolConfigs } from "../types";
+import {
+  AiToolConfig,
+  resolveAiToolConfigs,
+  TerminalBackendType,
+} from "../types";
 import { AiToolFileReference } from "../services/aiTools/AiToolOperator";
 import {
   TmuxSessionManager,
@@ -15,6 +19,8 @@ import {
 } from "../services/TmuxSessionManager";
 import { TerminalManager } from "../terminals/TerminalManager";
 import { AiToolOperatorRegistry } from "../services/aiTools/AiToolOperatorRegistry";
+import { ZellijSessionManager } from "../services/ZellijSessionManager";
+import { TerminalBackendRegistry } from "../services/terminalBackends";
 
 interface StartupWorkspaceResolution {
   workspacePath: string;
@@ -47,6 +53,9 @@ export class SessionRuntime {
   private lastKnownCols = 0;
   private lastKnownRows = 0;
   private selectedTmuxSessionId?: string;
+  private selectedZellijSessionId?: string;
+  private pendingBackendOverride?: TerminalBackendType;
+  private activeBackend: TerminalBackendType = "native";
   private forceNativeShellNextStart = false;
   private pendingLaunchToolName?: string;
   private activeTool?: AiToolConfig;
@@ -67,6 +76,8 @@ export class SessionRuntime {
     _openCodeApiClient: OpenCodeApiClient | undefined,
     private readonly portManager: PortManager,
     private readonly tmuxSessionManager: TmuxSessionManager | undefined,
+    private readonly zellijSessionManager: ZellijSessionManager | undefined,
+    private readonly backendRegistry: TerminalBackendRegistry,
     private readonly instanceStore: InstanceStore | undefined,
     private readonly logger: OutputChannelService,
     private readonly contextSharingService: ContextSharingService,
@@ -111,6 +122,45 @@ export class SessionRuntime {
 
   public getSelectedTmuxSessionId(): string | undefined {
     return this.selectedTmuxSessionId;
+  }
+
+  public getActiveBackend(): TerminalBackendType {
+    return this.activeBackend;
+  }
+
+  public getBackendAvailability() {
+    return this.backendRegistry.getAvailability();
+  }
+
+  public async cycleTerminalBackend(): Promise<void> {
+    await this.selectTerminalBackend(
+      this.backendRegistry.nextAvailable(this.activeBackend),
+    );
+  }
+
+  public async selectTerminalBackend(
+    backend: TerminalBackendType,
+  ): Promise<void> {
+    const resolved = this.backendRegistry.resolveAvailable(backend);
+    if (resolved === "native") {
+      await this.switchToNativeShell();
+      return;
+    }
+    if (resolved === "tmux") {
+      const sessionId = await this.ensureTmuxBackendSession();
+      if (sessionId) {
+        await this.switchToTmuxSession(sessionId);
+        return;
+      }
+      await this.switchToNativeShell();
+      return;
+    }
+    const sessionId = await this.ensureZellijBackendSession();
+    if (sessionId) {
+      await this.switchToZellijSession(sessionId);
+      return;
+    }
+    await this.switchToNativeShell();
   }
 
   public resolveToolByName(toolName: string): AiToolConfig | undefined {
@@ -225,24 +275,55 @@ export class SessionRuntime {
         this.resolveStartupWorkspacePath();
 
       const forceNativeShell = this.forceNativeShellNextStart;
-      const selectedTmuxSessionId = this.selectedTmuxSessionId;
-      let tmuxSessionId = forceNativeShell
-        ? undefined
-        : (selectedTmuxSessionId ??
-          this.resolveTmuxSessionIdForInstance(this.activeInstanceId));
+      const requestedBackend = forceNativeShell
+        ? "native"
+        : this.pendingBackendOverride ??
+          (this.selectedTmuxSessionId
+            ? "tmux"
+            : this.selectedZellijSessionId
+              ? "zellij"
+              : this.resolveConfiguredBackend(config));
+      const backend = this.backendRegistry.resolveAvailable(requestedBackend);
+      this.activeBackend = backend;
 
-      if (!forceNativeShell && !selectedTmuxSessionId && isWorkspaceScoped) {
-        const ensuredSessionId =
-          await this.ensureWorkspaceSession(workspacePath);
-        if (ensuredSessionId) {
-          tmuxSessionId = ensuredSessionId;
+      let tmuxSessionId: string | undefined;
+      let zellijSessionId: string | undefined;
+
+      if (backend === "tmux") {
+        const selectedTmuxSessionId = this.selectedTmuxSessionId;
+        tmuxSessionId =
+          selectedTmuxSessionId ??
+          this.resolveTmuxSessionIdForInstance(this.activeInstanceId);
+
+        if (!selectedTmuxSessionId && isWorkspaceScoped) {
+          const ensuredSessionId =
+            await this.ensureWorkspaceSession(workspacePath);
+          if (ensuredSessionId) {
+            tmuxSessionId = ensuredSessionId;
+          }
+        } else if (!selectedTmuxSessionId && !tmuxSessionId) {
+          tmuxSessionId = await this.resolveFallbackTmuxSessionId();
         }
-      } else if (
-        !forceNativeShell &&
-        !selectedTmuxSessionId &&
-        !tmuxSessionId
-      ) {
-        tmuxSessionId = await this.resolveFallbackTmuxSessionId();
+
+        if (!tmuxSessionId) {
+          this.activeBackend = "native";
+        }
+      } else if (backend === "zellij") {
+        zellijSessionId =
+          this.selectedZellijSessionId ??
+          this.resolveZellijSessionIdForInstance(this.activeInstanceId);
+
+        if (!zellijSessionId && isWorkspaceScoped) {
+          zellijSessionId = await this.ensureZellijWorkspaceSession(
+            workspacePath,
+          );
+        }
+        if (!zellijSessionId) {
+          zellijSessionId = await this.resolveFallbackZellijSessionId();
+        }
+        if (!zellijSessionId) {
+          this.activeBackend = "native";
+        }
       }
 
       if (tmuxSessionId && this.tmuxSessionManager) {
@@ -266,7 +347,10 @@ export class SessionRuntime {
 
       if (
         !forceNativeShell &&
-        (tmuxSessionId || this.pendingLaunchToolName || !this.tmuxSessionManager)
+        (this.activeBackend === "native" ||
+          Boolean(tmuxSessionId) ||
+          Boolean(zellijSessionId) ||
+          Boolean(this.pendingLaunchToolName))
       ) {
         resolvedTool = await this.resolveToolForStartup(config);
         if (!resolvedTool) {
@@ -282,10 +366,13 @@ export class SessionRuntime {
       const terminalCommand = this.resolveTerminalStartupCommand(
         command,
         tmuxSessionId,
+        zellijSessionId,
       );
 
       let port: number | undefined;
       this.selectedTmuxSessionId = undefined;
+      this.selectedZellijSessionId = undefined;
+      this.pendingBackendOverride = undefined;
       this.forceNativeShellNextStart = false;
       this.pendingLaunchToolName = undefined;
 
@@ -342,6 +429,8 @@ export class SessionRuntime {
                 ...existing.runtime,
                 terminalKey: this.activeInstanceId,
                 tmuxSessionId,
+                zellijSessionId,
+                terminalBackend: this.activeBackend,
                 port: port ?? existing.runtime.port,
               },
             });
@@ -354,6 +443,8 @@ export class SessionRuntime {
               runtime: {
                 terminalKey: this.activeInstanceId,
                 tmuxSessionId,
+                zellijSessionId,
+                terminalBackend: this.activeBackend,
                 port,
               },
               state: "connected",
@@ -370,7 +461,7 @@ export class SessionRuntime {
 
       this.isStarted = true;
 
-      this.notifyActiveSession(tmuxSessionId);
+      this.notifyActiveSession(tmuxSessionId ?? zellijSessionId, this.activeBackend);
 
       if (enableHttpApi && port) {
         this.apiClient = new OpenCodeApiClient(port, 10, 200, httpTimeout);
@@ -609,12 +700,32 @@ export class SessionRuntime {
   public resolveTerminalStartupCommand(
     defaultCommand: string | undefined,
     tmuxSessionId?: string,
+    zellijSessionId?: string,
   ): string | undefined {
-    if (!tmuxSessionId) {
-      return defaultCommand;
+    if (tmuxSessionId) {
+      return `tmux attach-session -t ${tmuxSessionId} \\; set-option -u status off`;
     }
+    if (zellijSessionId && this.zellijSessionManager) {
+      return this.zellijSessionManager.getAttachCommand(zellijSessionId);
+    }
+    return defaultCommand;
+  }
 
-    return `tmux attach-session -t ${tmuxSessionId} \\; set-option -u status off`;
+  public resolveConfiguredBackend(
+    config: vscode.WorkspaceConfiguration,
+  ): TerminalBackendType {
+    const configured = config.get<TerminalBackendType>(
+      "terminalBackend",
+      "tmux",
+    );
+    if (
+      configured === "native" ||
+      configured === "tmux" ||
+      configured === "zellij"
+    ) {
+      return configured;
+    }
+    return "tmux";
   }
 
   public resolveTmuxSessionIdForInstance(
@@ -625,6 +736,16 @@ export class SessionRuntime {
     }
 
     return this.instanceStore.get(instanceId)?.runtime.tmuxSessionId;
+  }
+
+  public resolveZellijSessionIdForInstance(
+    instanceId: InstanceId,
+  ): string | undefined {
+    if (!this.instanceStore) {
+      return undefined;
+    }
+
+    return this.instanceStore.get(instanceId)?.runtime.zellijSessionId;
   }
 
   public async resolveFallbackTmuxSessionId(): Promise<string | undefined> {
@@ -649,6 +770,62 @@ export class SessionRuntime {
     }
   }
 
+  public async resolveFallbackZellijSessionId(): Promise<string | undefined> {
+    if (!this.zellijSessionManager) {
+      return undefined;
+    }
+
+    try {
+      const sessions = await this.zellijSessionManager.discoverSessions();
+      if (sessions.length === 0) {
+        return undefined;
+      }
+      const preferredSession =
+        sessions.find((session) => session.isActive) ?? sessions[0];
+      return preferredSession?.id;
+    } catch (error) {
+      this.logger.warn(
+        `[TerminalProvider] Failed to resolve fallback zellij session: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return undefined;
+    }
+  }
+
+  public async ensureZellijWorkspaceSession(
+    workspacePath: string,
+  ): Promise<string | undefined> {
+    if (!this.zellijSessionManager) {
+      return undefined;
+    }
+
+    const sessionName = path.basename(workspacePath) || this.activeInstanceId;
+    try {
+      const result = await this.zellijSessionManager.ensureSession(
+        sessionName,
+        workspacePath,
+      );
+      this.logger.info(
+        `[TerminalProvider] zellij session ${result.action}: ${result.session.id}`,
+      );
+      return result.session.id;
+    } catch (error) {
+      this.logger.warn(
+        `[TerminalProvider] Failed to ensure zellij session: ${error instanceof Error ? error.message : String(error)}. Continuing with native startup.`,
+      );
+      return undefined;
+    }
+  }
+
+  private async ensureTmuxBackendSession(): Promise<string | undefined> {
+    const { workspacePath } = this.resolveStartupWorkspacePath();
+    return await this.ensureWorkspaceSession(workspacePath);
+  }
+
+  private async ensureZellijBackendSession(): Promise<string | undefined> {
+    const { workspacePath } = this.resolveStartupWorkspacePath();
+    return await this.ensureZellijWorkspaceSession(workspacePath);
+  }
+
   public resolveInstanceIdFromSessionId(sessionId: string): InstanceId {
     if (!this.instanceStore) {
       return this.activeInstanceId;
@@ -665,6 +842,13 @@ export class SessionRuntime {
     );
     if (tmuxMapped) {
       return tmuxMapped.config.id;
+    }
+
+    const zellijMapped = records.find(
+      (record) => record.runtime.zellijSessionId === sessionId,
+    );
+    if (zellijMapped) {
+      return zellijMapped.config.id;
     }
 
     const workspaceMapped = records.find((record) => {
@@ -705,7 +889,10 @@ export class SessionRuntime {
     }
 
     this.forceNativeShellNextStart = false;
+    this.pendingBackendOverride = "tmux";
+    this.activeBackend = "tmux";
     this.selectedTmuxSessionId = sessionId;
+    this.selectedZellijSessionId = undefined;
     this.pendingLaunchToolName = preferredToolName;
     if (preferredToolName) {
       const instanceId = this.resolveInstanceIdFromSessionId(sessionId);
@@ -721,26 +908,43 @@ export class SessionRuntime {
     this.notifyActiveSession(sessionId);
   }
 
+  public async switchToZellijSession(sessionId: string): Promise<void> {
+    this.forceNativeShellNextStart = false;
+    this.pendingBackendOverride = "zellij";
+    this.selectedTmuxSessionId = undefined;
+    this.selectedZellijSessionId = sessionId;
+    this.activeBackend = "zellij";
+    await this.switchToInstance(this.resolveInstanceIdFromSessionId(sessionId), {
+      forceRestart: true,
+    });
+    this.notifyActiveSession(sessionId, "zellij");
+  }
+
   public async switchToNativeShell(): Promise<void> {
     this.selectedTmuxSessionId = undefined;
+    this.selectedZellijSessionId = undefined;
+    this.pendingBackendOverride = "native";
+    this.activeBackend = "native";
     this.forceNativeShellNextStart = true;
     this.pendingLaunchToolName = undefined;
 
     if (this.instanceStore) {
       const existing = this.instanceStore.get(this.activeInstanceId);
-      if (existing?.runtime.tmuxSessionId) {
+      if (existing?.runtime.tmuxSessionId || existing?.runtime.zellijSessionId) {
         this.instanceStore.upsert({
           ...existing,
           runtime: {
             ...existing.runtime,
             tmuxSessionId: undefined,
+            zellijSessionId: undefined,
+            terminalBackend: "native",
           },
         });
       }
     }
 
     await this.switchToInstance(this.activeInstanceId, { forceRestart: true });
-    this.notifyActiveSession(undefined);
+    this.notifyActiveSession(undefined, "native");
   }
 
   public async createTmuxSession(): Promise<string | undefined> {
@@ -996,23 +1200,31 @@ export class SessionRuntime {
     } catch {}
   }
 
-  private notifyActiveSession(sessionId: string | undefined): void {
+  private notifyActiveSession(
+    sessionId: string | undefined,
+    backend: TerminalBackendType = this.activeBackend,
+  ): void {
     void vscode.commands.executeCommand(
       "setContext",
       "opencodeTui.tmuxAttached",
-      Boolean(sessionId),
+      backend === "tmux" && Boolean(sessionId),
     );
 
     if (!sessionId) {
       this.stopClipboardSync();
-      this.callbacks.postMessage({ type: "activeSession" });
+      this.callbacks.postMessage({ type: "activeSession", backend: "native" });
       return;
     }
-    this.startClipboardSync();
+    if (backend === "tmux") {
+      this.startClipboardSync();
+    } else {
+      this.stopClipboardSync();
+    }
     this.callbacks.postMessage({
       type: "activeSession",
       sessionName: sessionId,
       sessionId,
+      backend,
     });
   }
 

--- a/src/providers/SessionRuntime.ts
+++ b/src/providers/SessionRuntime.ts
@@ -834,12 +834,12 @@ export class SessionRuntime {
 
   private async ensureTmuxBackendSession(): Promise<string | undefined> {
     const { workspacePath } = this.resolveStartupWorkspacePath();
-    return await this.ensureWorkspaceSession(workspacePath);
+    return this.ensureWorkspaceSession(workspacePath);
   }
 
   private async ensureZellijBackendSession(): Promise<string | undefined> {
     const { workspacePath } = this.resolveStartupWorkspacePath();
-    return await this.ensureZellijWorkspaceSession(workspacePath);
+    return this.ensureZellijWorkspaceSession(workspacePath);
   }
 
   public resolveInstanceIdFromSessionId(sessionId: string): InstanceId {
@@ -1013,8 +1013,7 @@ export class SessionRuntime {
   }
 
   public async zoomTmuxPane(): Promise<void> {
-    const manager = this.activePaneManager;
-    if (!manager) {
+    if (!this.activePaneManager) {
       return;
     }
     if (this.activeBackend === "zellij") {
@@ -1128,8 +1127,7 @@ export class SessionRuntime {
     text: string,
     dropCell: { col: number; row: number },
   ): Promise<boolean> {
-    const manager = this.activePaneManager;
-    if (!manager) {
+    if (!this.activePaneManager) {
       return false;
     }
     if (this.activeBackend === "zellij") {
@@ -1391,8 +1389,7 @@ export class SessionRuntime {
   private async startExternalChangeMonitoring(
     sessionId: string,
   ): Promise<void> {
-    const manager = this.activePaneManager;
-    if (!manager) {
+    if (!this.activePaneManager) {
       return;
     }
 
@@ -1485,8 +1482,7 @@ export class SessionRuntime {
   }
 
   private async checkPaneChanges(): Promise<void> {
-    const manager = this.activePaneManager;
-    if (!manager) {
+    if (!this.activePaneManager) {
       return;
     }
 

--- a/src/providers/SessionRuntime.ts
+++ b/src/providers/SessionRuntime.ts
@@ -132,6 +132,16 @@ export class SessionRuntime {
     return this.backendRegistry.getAvailability();
   }
 
+  private get activePaneManager(): TmuxSessionManager | ZellijSessionManager | null {
+    if (this.activeBackend === "tmux") {
+      return this.tmuxSessionManager ?? null;
+    }
+    if (this.activeBackend === "zellij") {
+      return this.zellijSessionManager ?? null;
+    }
+    return null;
+  }
+
   public async cycleTerminalBackend(): Promise<void> {
     await this.selectTerminalBackend(
       this.backendRegistry.nextAvailable(this.activeBackend),
@@ -876,6 +886,13 @@ export class SessionRuntime {
     sessionId: string,
     preferredToolName?: string,
   ): Promise<void> {
+    this.forceNativeShellNextStart = false;
+    this.pendingBackendOverride = "tmux";
+    this.activeBackend = "tmux";
+    this.selectedTmuxSessionId = sessionId;
+    this.selectedZellijSessionId = undefined;
+    this.pendingLaunchToolName = preferredToolName;
+
     if (this.tmuxSessionManager) {
       try {
         await this.tmuxSessionManager.registerSessionHooks(
@@ -887,13 +904,6 @@ export class SessionRuntime {
         await this.startExternalChangeMonitoring(sessionId);
       } catch {}
     }
-
-    this.forceNativeShellNextStart = false;
-    this.pendingBackendOverride = "tmux";
-    this.activeBackend = "tmux";
-    this.selectedTmuxSessionId = sessionId;
-    this.selectedZellijSessionId = undefined;
-    this.pendingLaunchToolName = preferredToolName;
     if (preferredToolName) {
       const instanceId = this.resolveInstanceIdFromSessionId(sessionId);
       this.persistSelectedTool(preferredToolName, instanceId);
@@ -914,6 +924,23 @@ export class SessionRuntime {
     this.selectedTmuxSessionId = undefined;
     this.selectedZellijSessionId = sessionId;
     this.activeBackend = "zellij";
+
+    if (this.zellijSessionManager) {
+      try {
+        await this.zellijSessionManager.switchSession(sessionId);
+      } catch (error) {
+        this.logger.warn(
+          `[TerminalProvider] Failed to switch zellij session before attach: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      try {
+        await this.startExternalChangeMonitoring(sessionId);
+      } catch (error) {
+        this.logger.warn(
+          `[TerminalProvider] Failed to start zellij change monitoring: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
     await this.switchToInstance(this.resolveInstanceIdFromSessionId(sessionId), {
       forceRestart: true,
     });
@@ -980,6 +1007,20 @@ export class SessionRuntime {
   }
 
   public async zoomTmuxPane(): Promise<void> {
+    const manager = this.activePaneManager;
+    if (!manager) {
+      return;
+    }
+    if (this.activeBackend === "zellij") {
+      try {
+        await this.zellijSessionManager?.zoomPane();
+      } catch (error) {
+        this.logger.error(
+          `[TerminalProvider] Failed to zoom zellij pane: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      return;
+    }
     if (!this.tmuxSessionManager) {
       return;
     }
@@ -1007,6 +1048,16 @@ export class SessionRuntime {
   }
 
   public async killTmuxSession(sessionId: string): Promise<void> {
+    const backend = this.resolveBackendForSession(sessionId);
+    if (backend === "native") {
+      return;
+    }
+
+    if (backend === "zellij") {
+      await this.killZellijSession(sessionId);
+      return;
+    }
+
     if (!this.tmuxSessionManager) {
       return;
     }
@@ -1071,6 +1122,21 @@ export class SessionRuntime {
     text: string,
     dropCell: { col: number; row: number },
   ): Promise<boolean> {
+    const manager = this.activePaneManager;
+    if (!manager) {
+      return false;
+    }
+    if (this.activeBackend === "zellij") {
+      try {
+        await this.zellijSessionManager?.sendTextToPane(text, { submit: false });
+        return true;
+      } catch (error) {
+        this.logger.warn(
+          `[TerminalProvider] Failed to route dropped text to zellij pane: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return false;
+      }
+    }
     if (!this.tmuxSessionManager) {
       return false;
     }
@@ -1102,8 +1168,80 @@ export class SessionRuntime {
         submit: false,
       });
       return true;
-    } catch {
+    } catch (error) {
+      this.logger.warn(
+        `[TerminalProvider] Failed to route dropped text to tmux pane: ${error instanceof Error ? error.message : String(error)}`,
+      );
       return false;
+    }
+  }
+
+  private resolveBackendForSession(sessionId: string): TerminalBackendType {
+    if (this.activeBackend !== "native") {
+      return this.activeBackend;
+    }
+    if (this.selectedZellijSessionId === sessionId) {
+      return "zellij";
+    }
+    if (this.selectedTmuxSessionId === sessionId) {
+      return "tmux";
+    }
+    if (this.instanceStore) {
+      const records = this.instanceStore.getAll();
+      if (records.some((record) => record.runtime.zellijSessionId === sessionId)) {
+        return "zellij";
+      }
+      if (records.some((record) => record.runtime.tmuxSessionId === sessionId)) {
+        return "tmux";
+      }
+    }
+    return this.tmuxSessionManager ? "tmux" : "native";
+  }
+
+  private async killZellijSession(sessionId: string): Promise<void> {
+    if (!this.zellijSessionManager) {
+      return;
+    }
+
+    try {
+      const activeZellijSessionId = this.resolveZellijSessionIdForInstance(
+        this.activeInstanceId,
+      );
+      const shouldFallbackToNative =
+        this.selectedZellijSessionId === sessionId ||
+        activeZellijSessionId === sessionId;
+
+      if (this.selectedZellijSessionId === sessionId) {
+        this.selectedZellijSessionId = undefined;
+      }
+
+      await this.zellijSessionManager.killSession(sessionId);
+
+      if (this.instanceStore) {
+        const records = this.instanceStore.getAll();
+        for (const record of records) {
+          if (record.runtime.zellijSessionId === sessionId) {
+            this.portManager.releaseTerminalPorts(record.config.id);
+            this.instanceStore.upsert({
+              ...record,
+              runtime: {
+                ...record.runtime,
+                zellijSessionId: undefined,
+                port: undefined,
+              },
+            });
+          }
+        }
+      }
+
+      if (shouldFallbackToNative && this.isStarted) {
+        await this.switchToNativeShell();
+      }
+    } catch (error) {
+      this.logger.error(
+        `[TerminalProvider] Failed to kill zellij session: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      vscode.window.showErrorMessage("Failed to kill zellij session");
     }
   }
 
@@ -1230,7 +1368,7 @@ export class SessionRuntime {
 
   private startClipboardSync(): void {
     this.stopClipboardSync();
-    if (!this.tmuxSessionManager) {
+    if (this.activeBackend !== "tmux" || !this.tmuxSessionManager) {
       return;
     }
     this.clipboardPollInterval = setInterval(async () => {
@@ -1247,23 +1385,58 @@ export class SessionRuntime {
   private async startExternalChangeMonitoring(
     sessionId: string,
   ): Promise<void> {
-    if (!this.tmuxSessionManager) {
+    const manager = this.activePaneManager;
+    if (!manager) {
       return;
     }
 
     try {
-      const panes = await this.tmuxSessionManager.listPanes(sessionId, {
-        activeWindowOnly: true,
-      });
-      this.knownPaneIds.set(sessionId, new Set(panes.map((p) => p.paneId)));
-      const activePane = panes.find((p) => p.isActive);
-      if (activePane?.paneId) {
+      const panes =
+        this.activeBackend === "tmux" && this.tmuxSessionManager
+          ? await this.tmuxSessionManager.listPanes(sessionId, {
+              activeWindowOnly: true,
+            })
+          : await this.zellijSessionManager!.listPanes();
+      this.knownPaneIds.set(
+        sessionId,
+        new Set(
+          panes.map((p) => ("paneId" in p ? p.paneId : p.id)),
+        ),
+      );
+      const activePane = panes.find((p) =>
+        "isActive" in p ? p.isActive : p.isFocused,
+      );
+      const activePaneId = activePane
+        ? "paneId" in activePane
+          ? activePane.paneId
+          : activePane.id
+        : undefined;
+      if (activePane && activePaneId) {
+        const activePaneCommand =
+          "currentCommand" in activePane ? activePane.currentCommand ?? "" : "";
         this.knownPaneCommands.set(
-          `${sessionId}:${activePane.paneId}`,
-          activePane.currentCommand ?? "",
+          `${sessionId}:${activePaneId}`,
+          activePaneCommand,
         );
       }
-    } catch {}
+    } catch (error) {
+      this.logger.warn(
+        `[TerminalProvider] Failed to initialize pane monitoring: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    if (this.activeBackend === "zellij") {
+      if (!this.paneMonitorInterval) {
+        this.paneMonitorInterval = setInterval(() => {
+          void this.checkPaneChanges();
+        }, 1500);
+      }
+      return;
+    }
+
+    if (!this.tmuxSessionManager) {
+      return;
+    }
 
     if (!this.sigusr2Handler) {
       this.sigusr2Handler = () => {
@@ -1306,6 +1479,16 @@ export class SessionRuntime {
   }
 
   private async checkPaneChanges(): Promise<void> {
+    const manager = this.activePaneManager;
+    if (!manager) {
+      return;
+    }
+
+    if (this.activeBackend === "zellij") {
+      await this.checkZellijPaneChanges();
+      return;
+    }
+
     if (!this.tmuxSessionManager) {
       return;
     }
@@ -1320,7 +1503,11 @@ export class SessionRuntime {
         if (sessions.length > 0) {
           activeSessionId = sessions[0].id;
         }
-      } catch {}
+      } catch (error) {
+        this.logger.warn(
+          `[TerminalProvider] Failed to discover tmux sessions during pane monitoring: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
     }
 
     if (!activeSessionId) {
@@ -1365,7 +1552,75 @@ export class SessionRuntime {
           canKillPane,
         });
       }
-    } catch {}
+    } catch (error) {
+      this.logger.warn(
+        `[TerminalProvider] Failed to check tmux pane changes: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  private async checkZellijPaneChanges(): Promise<void> {
+    if (!this.zellijSessionManager) {
+      return;
+    }
+
+    let activeSessionId =
+      this.selectedZellijSessionId ??
+      this.resolveZellijSessionIdForInstance(this.activeInstanceId);
+
+    if (!activeSessionId) {
+      try {
+        const sessions = await this.zellijSessionManager.discoverSessions();
+        if (sessions.length > 0) {
+          activeSessionId = sessions[0].id;
+        }
+      } catch (error) {
+        this.logger.warn(
+          `[TerminalProvider] Failed to discover zellij sessions during pane monitoring: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
+    if (!activeSessionId) {
+      return;
+    }
+
+    try {
+      const [panes, tabs] = await Promise.all([
+        this.zellijSessionManager.listPanes(),
+        this.zellijSessionManager.listTabs(),
+      ]);
+      const currentPaneIds = new Set(panes.map((pane) => pane.id));
+      this.knownPaneIds.set(activeSessionId, currentPaneIds);
+      for (const pane of panes) {
+        this.knownPaneCommands.set(`${activeSessionId}:${pane.id}`, pane.title);
+      }
+
+      const activeTab = tabs.find((tab) => tab.isActive);
+      const activeWindowId = activeTab ? String(activeTab.index) : undefined;
+      const windowChanged =
+        activeWindowId !== undefined && activeWindowId !== this.knownActiveWindowId;
+      const canKillPane = panes.length > 1 || tabs.length > 1;
+
+      if (windowChanged || canKillPane !== this._lastCanKillPane) {
+        if (windowChanged) {
+          this.knownActiveWindowId = activeWindowId;
+        }
+        this._lastCanKillPane = canKillPane;
+        this.callbacks.postMessage({
+          type: "activeSession",
+          sessionName: activeSessionId,
+          sessionId: activeSessionId,
+          windowIndex: activeTab?.index,
+          windowName: activeTab?.name,
+          canKillPane,
+        });
+      }
+    } catch (error) {
+      this.logger.warn(
+        `[TerminalProvider] Failed to check zellij pane changes: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   private stopClipboardSync(): void {

--- a/src/providers/TerminalDashboardProvider.test.ts
+++ b/src/providers/TerminalDashboardProvider.test.ts
@@ -20,9 +20,6 @@ vi.mock("vscode", async () => {
   return actual;
 });
 
-/**
- * Tests for the TerminalDashboardProvider class.
- */
 describe("TerminalDashboardProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -35,18 +32,12 @@ describe("TerminalDashboardProvider", () => {
     ];
   });
 
-  /**
-   * Flushes the promise queue to ensure all async operations are completed.
-   */
   async function flushPromises(): Promise<void> {
     for (let i = 0; i < 6; i += 1) {
       await Promise.resolve();
     }
   }
 
-  /**
-   * Creates an instance of TerminalDashboardProvider with mocked dependencies.
-   */
   function createProvider(options?: {
     discoverSessions?: ReturnType<typeof vi.fn>;
     listPanes?: ReturnType<typeof vi.fn>;
@@ -154,9 +145,6 @@ describe("TerminalDashboardProvider", () => {
     };
   }
 
-  /**
-   * Resolves the webview view for the provider and returns the view and message handler.
-   */
   function resolveProvider(provider: TerminalDashboardProvider) {
     const view = vscode.WebviewView();
     provider.resolveWebviewView(view as never, {} as never, {} as never);
@@ -203,9 +191,6 @@ describe("TerminalDashboardProvider", () => {
     return { panel, messageHandler };
   }
 
-  /**
-   * Verifies that only sessions matching the current workspace are posted to the webview.
-   */
   it("posts workspace-filtered tmux sessions to the dashboard webview", async () => {
     const { provider } = createProvider({
       discoverSessions: vi.fn().mockResolvedValue([
@@ -343,9 +328,6 @@ describe("TerminalDashboardProvider", () => {
     );
   });
 
-  /**
-   * Verifies that webview actions trigger the correct VS Code commands and refresh the session list.
-   */
   it("routes activate/create/native actions through commands and refreshes", async () => {
     const { provider, discoverSessions } = createProvider({
       discoverSessions: vi.fn().mockResolvedValue([
@@ -402,9 +384,6 @@ describe("TerminalDashboardProvider", () => {
     );
   });
 
-  /**
-   * Verifies that the refresh action triggers a session discovery.
-   */
   it("refreshes sessions when the refresh action is received", async () => {
     const { provider, discoverSessions } = createProvider();
     const { view, messageHandler } = resolveProvider(provider);

--- a/src/providers/TerminalDashboardProvider.test.ts
+++ b/src/providers/TerminalDashboardProvider.test.ts
@@ -39,8 +39,9 @@ describe("TerminalDashboardProvider", () => {
    * Flushes the promise queue to ensure all async operations are completed.
    */
   async function flushPromises(): Promise<void> {
-    await Promise.resolve();
-    await Promise.resolve();
+    for (let i = 0; i < 6; i += 1) {
+      await Promise.resolve();
+    }
   }
 
   /**
@@ -51,6 +52,9 @@ describe("TerminalDashboardProvider", () => {
     listPanes?: ReturnType<typeof vi.fn>;
     listWindows?: ReturnType<typeof vi.fn>;
     listWindowPaneGeometry?: ReturnType<typeof vi.fn>;
+    zellijDiscoverSessions?: ReturnType<typeof vi.fn>;
+    zellijListPanes?: ReturnType<typeof vi.fn>;
+    zellijListTabs?: ReturnType<typeof vi.fn>;
     instanceStore?: {
       getAll: ReturnType<typeof vi.fn>;
       getActive?: ReturnType<typeof vi.fn>;
@@ -61,6 +65,8 @@ describe("TerminalDashboardProvider", () => {
     terminalProvider?: {
       showAiToolSelector: ReturnType<typeof vi.fn>;
       launchAiTool: ReturnType<typeof vi.fn>;
+      switchToZellijSession?: ReturnType<typeof vi.fn>;
+      killTmuxSession?: ReturnType<typeof vi.fn>;
     };
     logger?: {
       debug: ReturnType<typeof vi.fn>;
@@ -76,6 +82,9 @@ describe("TerminalDashboardProvider", () => {
       options?.listWindowPaneGeometry ?? vi.fn().mockResolvedValue([]);
     const instanceStore = options?.instanceStore;
     const terminalProvider = options?.terminalProvider;
+    const zellijDiscoverSessions = options?.zellijDiscoverSessions;
+    const zellijListPanes = options?.zellijListPanes ?? vi.fn().mockResolvedValue([]);
+    const zellijListTabs = options?.zellijListTabs ?? vi.fn().mockResolvedValue([]);
     const logger =
       options?.logger ??
       ({
@@ -104,23 +113,43 @@ describe("TerminalDashboardProvider", () => {
       listPaneDtos: vi.fn().mockResolvedValue([]),
       onPaneChanged: onPaneChangedEvent.event,
     } as unknown as TmuxSessionManager;
+    const zellijSessionManager = zellijDiscoverSessions
+      ? {
+          discoverSessions: zellijDiscoverSessions,
+          listPanes: zellijListPanes,
+          listTabs: zellijListTabs,
+          createTab: vi.fn().mockResolvedValue(undefined),
+          nextTab: vi.fn().mockResolvedValue(undefined),
+          prevTab: vi.fn().mockResolvedValue(undefined),
+          killTab: vi.fn().mockResolvedValue(undefined),
+          selectTab: vi.fn().mockResolvedValue(undefined),
+          selectPane: vi.fn().mockResolvedValue(undefined),
+          splitPane: vi.fn().mockResolvedValue("terminal_8"),
+          killPane: vi.fn().mockResolvedValue(undefined),
+          resizePane: vi.fn().mockResolvedValue(undefined),
+        }
+      : undefined;
 
     return {
       discoverSessions,
       listPanes,
       listWindows,
       listWindowPaneGeometry,
+      zellijListPanes,
+      zellijListTabs,
       logger,
       instanceStore,
       terminalProvider,
       onPaneChangedEvent,
       tmuxSessionManager,
+      zellijSessionManager,
       provider: new TerminalDashboardProvider(
         context as never,
         tmuxSessionManager,
         logger as never,
         instanceStore as never,
         terminalProvider as never,
+        zellijSessionManager as never,
       ),
     };
   }
@@ -237,6 +266,79 @@ describe("TerminalDashboardProvider", () => {
             label: "Codex",
           }),
         ]),
+      }),
+    );
+  });
+
+  it("posts zellij sessions with tabs mapped to dashboard windows", async () => {
+    const { provider, zellijListPanes, zellijListTabs } = createProvider({
+      discoverSessions: vi.fn().mockResolvedValue([]),
+      zellijDiscoverSessions: vi.fn().mockResolvedValue([
+        {
+          id: "repo-a",
+          name: "repo-a",
+          workspace: "repo-a",
+          isActive: true,
+        },
+        {
+          id: "repo-b",
+          name: "repo-b",
+          workspace: "repo-b",
+          isActive: false,
+        },
+      ]),
+      zellijListTabs: vi.fn().mockResolvedValue([
+        { index: 1, name: "editor", isActive: true },
+        { index: 2, name: "tests", isActive: false },
+      ]),
+      zellijListPanes: vi.fn().mockResolvedValue([
+        {
+          id: "terminal_1",
+          title: "shell",
+          isFocused: true,
+          isFloating: false,
+        },
+      ]),
+    });
+
+    const { view } = resolveProvider(provider);
+    await flushPromises();
+
+    expect(zellijListTabs).toHaveBeenCalledTimes(1);
+    expect(zellijListPanes).toHaveBeenCalledTimes(1);
+    expect(view.webview.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessions: [
+          {
+            id: "repo-a",
+            name: "Zellij: repo-a",
+            workspace: "repo-a",
+            isActive: true,
+            paneCount: 1,
+          },
+        ],
+        panes: {
+          "repo-a": [
+            expect.objectContaining({
+              paneId: "terminal_1",
+              isActive: true,
+              windowId: "zellij-tab-1",
+            }),
+          ],
+        },
+        windows: {
+          "repo-a": [
+            expect.objectContaining({
+              windowId: "zellij-tab-1",
+              name: "Tab: editor",
+              panes: [expect.objectContaining({ paneId: "terminal_1" })],
+            }),
+            expect.objectContaining({
+              windowId: "zellij-tab-2",
+              name: "Tab: tests",
+            }),
+          ],
+        },
       }),
     );
   });
@@ -598,7 +700,7 @@ describe("TerminalDashboardProvider", () => {
     visibilityHandler();
     await flushPromises();
 
-    expect(vi.mocked(view.webview.postMessage)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(view.webview.postMessage)).toHaveBeenCalledTimes(4);
     expect(discoverSessions).toHaveBeenCalledTimes(3);
   });
 
@@ -890,6 +992,86 @@ describe("TerminalDashboardProvider", () => {
       true,
       undefined,
     );
+  });
+
+  it("routes zellij tab and pane actions through the zellij manager", async () => {
+    const terminalProvider = {
+      showAiToolSelector: vi.fn(),
+      launchAiTool: vi.fn().mockResolvedValue(undefined),
+      switchToZellijSession: vi.fn().mockResolvedValue(undefined),
+      killTmuxSession: vi.fn().mockResolvedValue(undefined),
+    };
+    const { provider, zellijSessionManager } = createProvider({
+      discoverSessions: vi.fn().mockResolvedValue([]),
+      zellijDiscoverSessions: vi.fn().mockResolvedValue([
+        { id: "repo-a", name: "repo-a", workspace: "repo-a", isActive: true },
+      ]),
+      zellijListPanes: vi.fn().mockResolvedValue([
+        {
+          id: "terminal_1",
+          title: "active",
+          isFocused: true,
+          isFloating: false,
+        },
+      ]),
+      zellijListTabs: vi.fn().mockResolvedValue([
+        { index: 1, name: "main", isActive: true },
+      ]),
+      terminalProvider,
+    });
+
+    const { messageHandler } = resolveProvider(provider);
+    await flushPromises();
+
+    await messageHandler({ action: "activate", sessionId: "repo-a" });
+    await messageHandler({ action: "createWindow", sessionId: "repo-a" });
+    await messageHandler({ action: "nextWindow", sessionId: "repo-a" });
+    await messageHandler({ action: "prevWindow", sessionId: "repo-a" });
+    await messageHandler({
+      action: "selectWindow",
+      sessionId: "repo-a",
+      windowId: "zellij-tab-2",
+    });
+    await messageHandler({ action: "killWindow", sessionId: "repo-a" });
+    await messageHandler({
+      action: "switchPane",
+      sessionId: "repo-a",
+      paneId: "terminal_1",
+    });
+    await messageHandler({
+      action: "splitPaneWithCommand",
+      sessionId: "repo-a",
+      paneId: "terminal_1",
+      direction: "h",
+      command: "npm test",
+    });
+    await messageHandler({
+      action: "resizePane",
+      sessionId: "repo-a",
+      paneId: "terminal_1",
+      direction: "L",
+      amount: 5,
+    });
+    await messageHandler({
+      action: "killPane",
+      sessionId: "repo-a",
+      paneId: "terminal_1",
+    });
+
+    expect(terminalProvider.switchToZellijSession).toHaveBeenCalledWith("repo-a");
+    expect(zellijSessionManager?.createTab).toHaveBeenCalledWith({
+      workingDirectory: "/workspaces/repo-a",
+    });
+    expect(zellijSessionManager?.nextTab).toHaveBeenCalled();
+    expect(zellijSessionManager?.prevTab).toHaveBeenCalled();
+    expect(zellijSessionManager?.selectTab).toHaveBeenCalledWith(2);
+    expect(zellijSessionManager?.killTab).toHaveBeenCalled();
+    expect(zellijSessionManager?.selectPane).toHaveBeenCalledWith("terminal_1");
+    expect(zellijSessionManager?.splitPane).toHaveBeenCalledWith("h", {
+      command: "npm test",
+    });
+    expect(zellijSessionManager?.resizePane).toHaveBeenCalledWith("left", 5);
+    expect(zellijSessionManager?.killPane).toHaveBeenCalled();
   });
 
   it("uses the active pane target when opening the AI selector and falls back gracefully on pane lookup errors", async () => {

--- a/src/providers/TerminalDashboardProvider.ts
+++ b/src/providers/TerminalDashboardProvider.ts
@@ -354,21 +354,21 @@ export class TerminalDashboardProvider
   }
 
   private async getSessionBackend(sessionId: string): Promise<DashboardBackend> {
-    if (!this.zellijSessionManager) {
-      return "tmux";
-    }
-
-    try {
-      const zellijSessions = await this.zellijSessionManager.discoverSessions();
-      if (zellijSessions.some((session) => session.id === sessionId)) {
-        return "zellij";
+    if (this.zellijSessionManager) {
+      try {
+        const zellijSessions = await this.zellijSessionManager.discoverSessions();
+        if (zellijSessions.some((session) => session.id === sessionId)) {
+          return "zellij";
+        }
+      } catch (error) {
+        this.logger?.warn(
+          `[TerminalDashboard] Failed to resolve zellij session backend: ${error instanceof Error ? error.message : String(error)}`,
+        );
       }
-    } catch (error) {
-      this.logger?.warn(
-        `[TerminalDashboard] Failed to resolve zellij session backend: ${error instanceof Error ? error.message : String(error)}`,
-      );
     }
 
+    // Default to tmux (the tmuxSessionManager is always provided via constructor).
+    // If the session was not found in zellij, it is treated as a tmux session.
     return "tmux";
   }
 
@@ -383,6 +383,7 @@ export class TerminalDashboardProvider
       return;
     }
 
+    try {
     switch (message.action) {
       case "refresh":
         await this.postSessionsToWebview();
@@ -715,6 +716,12 @@ export class TerminalDashboardProvider
       }
       default:
         return;
+    }
+    } catch (error) {
+      this.logger?.error(
+        `[TerminalDashboard] Error handling \"${message.action}\" action: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      await this.postSessionsToWebview();
     }
   }
 

--- a/src/providers/TerminalDashboardProvider.ts
+++ b/src/providers/TerminalDashboardProvider.ts
@@ -848,19 +848,21 @@ export class TerminalDashboardProvider
       return this.instanceStore
         .getAll()
         .filter((record) => {
-          // Only include native shell instances (no tmux session)
           if (record.runtime.tmuxSessionId) {
             return false;
           }
-          // Filter by workspace if available
-          if (workspacePath) {
-            const recordWorkspace = record.config.workspaceUri
-              ? vscode.Uri.parse(record.config.workspaceUri).fsPath
-              : undefined;
-            if (recordWorkspace !== workspacePath) {
-              return false;
-            }
+          if (!workspacePath) {
+            return true;
           }
+
+          const recordWorkspace = record.config.workspaceUri
+            ? vscode.Uri.parse(record.config.workspaceUri).fsPath
+            : undefined;
+
+          if (recordWorkspace !== workspacePath) {
+            return false;
+          }
+
           return true;
         })
         .map((record) => ({

--- a/src/providers/TerminalDashboardProvider.ts
+++ b/src/providers/TerminalDashboardProvider.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import type { ILogger } from "../services/ILogger";
 import { TmuxSessionManager } from "../services/TmuxSessionManager";
+import { ZellijSessionManager } from "../services/ZellijSessionManager";
 import { InstanceStore } from "../services/InstanceStore";
 import type { TerminalProvider } from "./TerminalProvider";
 import {
@@ -15,6 +16,16 @@ import {
   AiToolConfig,
   resolveAiToolConfigs,
 } from "../types";
+
+type DashboardBackend = "tmux" | "zellij";
+
+interface DashboardSessionSource {
+  id: string;
+  name: string;
+  workspace: string;
+  isActive: boolean;
+  backend: DashboardBackend;
+}
 
 /**
  * Terminal Managers provider. Webview-based tmux session manager with inline pane controls (split, switch, resize, swap, kill). Filters sessions to current workspace.
@@ -39,6 +50,7 @@ export class TerminalDashboardProvider
     private readonly logger?: ILogger,
     private readonly instanceStore?: InstanceStore,
     private readonly terminalProvider?: TerminalProvider,
+    private readonly zellijSessionManager?: ZellijSessionManager,
   ) {}
 
   /**
@@ -132,7 +144,7 @@ export class TerminalDashboardProvider
     const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 
     try {
-      const sessions = await this.tmuxSessionManager.discoverSessions();
+      const sessions = await this.discoverDashboardSessions();
       const workspaceName = workspacePath
         ? path.basename(workspacePath)
         : undefined;
@@ -142,7 +154,7 @@ export class TerminalDashboardProvider
       );
       for (const s of sessions) {
         this.logger?.debug(
-          `[TerminalDashboard]   session: id=${s.id}, workspace=${s.workspace}, isActive=${s.isActive}`,
+          `[TerminalDashboard]   session: id=${s.id}, workspace=${s.workspace}, isActive=${s.isActive}, backend=${s.backend}`,
         );
       }
 
@@ -166,26 +178,35 @@ export class TerminalDashboardProvider
       );
       for (const session of filtered) {
         try {
-          const windows = await this.tmuxSessionManager.listWindows(session.id);
-          const windowPanes = await Promise.all(
-            windows.map((w) =>
-              this.tmuxSessionManager.listWindowPaneGeometry(
-                session.id,
-                w.windowId,
-                tools,
+          if (session.backend === "zellij") {
+            const { panes, windows } = await this.buildZellijWindowData();
+            panesMap[session.id] = panes;
+            windowsMap[session.id] = windows;
+          } else {
+            const windows = await this.tmuxSessionManager.listWindows(session.id);
+            const windowPanes = await Promise.all(
+              windows.map((w) =>
+                this.tmuxSessionManager.listWindowPaneGeometry(
+                  session.id,
+                  w.windowId,
+                  tools,
+                ),
               ),
-            ),
+            );
+            const allPanes = windowPanes.flat();
+            panesMap[session.id] = allPanes;
+            windowsMap[session.id] = windows.map((w, i) => ({
+              windowId: w.windowId,
+              index: w.index,
+              name: w.name,
+              isActive: w.isActive,
+              panes: windowPanes[i] ?? [],
+            }));
+          }
+        } catch (error) {
+          this.logger?.warn(
+            `[TerminalDashboard] Failed to load ${session.backend} panes for ${session.id}: ${error instanceof Error ? error.message : String(error)}`,
           );
-          const allPanes = windowPanes.flat();
-          panesMap[session.id] = allPanes;
-          windowsMap[session.id] = windows.map((w, i) => ({
-            windowId: w.windowId,
-            index: w.index,
-            name: w.name,
-            isActive: w.isActive,
-            panes: windowPanes[i] ?? [],
-          }));
-        } catch {
           panesMap[session.id] = [];
           windowsMap[session.id] = [];
         }
@@ -193,7 +214,7 @@ export class TerminalDashboardProvider
 
       const payload: TmuxDashboardSessionDto[] = filtered.map((session) => ({
         id: session.id,
-        name: session.name,
+        name: session.backend === "zellij" ? `Zellij: ${session.name}` : session.name,
         workspace: session.workspace,
         isActive: session.isActive,
         paneCount: panesMap[session.id]?.length ?? 0,
@@ -241,6 +262,116 @@ export class TerminalDashboardProvider
     }
   }
 
+  private async discoverDashboardSessions(): Promise<DashboardSessionSource[]> {
+    const sessions: DashboardSessionSource[] = [];
+
+    try {
+      const tmuxSessions = await this.tmuxSessionManager.discoverSessions();
+      sessions.push(
+        ...tmuxSessions.map((session) => ({
+          ...session,
+          backend: "tmux" as const,
+        })),
+      );
+    } catch (error) {
+      this.logger?.warn(
+        `[TerminalDashboard] Failed to discover tmux sessions: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      if (!this.zellijSessionManager) {
+        throw error;
+      }
+    }
+
+    if (!this.zellijSessionManager) {
+      return sessions;
+    }
+
+    try {
+      const zellijSessions = await this.zellijSessionManager.discoverSessions();
+      sessions.push(
+        ...zellijSessions.map((session) => ({
+          ...session,
+          backend: "zellij" as const,
+        })),
+      );
+    } catch (error) {
+      this.logger?.warn(
+        `[TerminalDashboard] Failed to discover zellij sessions: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    return sessions;
+  }
+
+  private async buildZellijWindowData(): Promise<{
+    panes: TmuxDashboardPaneDto[];
+    windows: TmuxDashboardWindowDto[];
+  }> {
+    if (!this.zellijSessionManager) {
+      return { panes: [], windows: [] };
+    }
+
+    const [tabs, zellijPanes] = await Promise.all([
+      this.zellijSessionManager.listTabs(),
+      this.zellijSessionManager.listPanes(),
+    ]);
+    const activeTab = tabs.find((tab) => tab.isActive) ?? tabs[0];
+    const activeWindowId = activeTab ? this.zellijTabWindowId(activeTab.index) : "zellij-tab-1";
+    const panes: TmuxDashboardPaneDto[] = zellijPanes.map((pane, index) => ({
+      paneId: pane.id,
+      index,
+      title: pane.title,
+      isActive: pane.isFocused,
+      windowId: activeWindowId,
+    }));
+    const windows = tabs.map((tab) => ({
+      windowId: this.zellijTabWindowId(tab.index),
+      index: tab.index,
+      name: `Tab: ${tab.name}`,
+      isActive: tab.isActive,
+      panes: tab.index === activeTab?.index ? panes : [],
+    }));
+
+    return {
+      panes,
+      windows: windows.length > 0 ? windows : [{
+        windowId: activeWindowId,
+        index: 1,
+        name: "Tab 1",
+        isActive: true,
+        panes,
+      }],
+    };
+  }
+
+  private zellijTabWindowId(index: number): string {
+    return `zellij-tab-${index}`;
+  }
+
+  private parseZellijTabIndex(windowId: string | undefined): number {
+    const match = windowId?.match(/^(?:zellij-tab-)?(\d+)$/);
+    return match?.[1] ? Number(match[1]) : 1;
+  }
+
+  private async getSessionBackend(sessionId: string): Promise<DashboardBackend> {
+    if (!this.zellijSessionManager) {
+      return "tmux";
+    }
+
+    try {
+      const zellijSessions = await this.zellijSessionManager.discoverSessions();
+      if (zellijSessions.some((session) => session.id === sessionId)) {
+        return "zellij";
+      }
+    } catch (error) {
+      this.logger?.warn(
+        `[TerminalDashboard] Failed to resolve zellij session backend: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    return "tmux";
+  }
+
   /**
    * Handles incoming messages from the webview and executes corresponding commands or actions.
    * @param message The message received from the webview
@@ -261,10 +392,14 @@ export class TerminalDashboardProvider
         await this.postSessionsToWebview();
         return;
       case "activate":
-        await vscode.commands.executeCommand(
-          "opencodeTui.switchTmuxSession",
-          message.sessionId,
-        );
+        if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+          await this.terminalProvider?.switchToZellijSession(message.sessionId);
+        } else {
+          await vscode.commands.executeCommand(
+            "opencodeTui.switchTmuxSession",
+            message.sessionId,
+          );
+        }
         await this.postSessionsToWebview();
         return;
       case "create":
@@ -321,16 +456,24 @@ export class TerminalDashboardProvider
         // Get the active pane to use as the default target for AI tool launch
         let targetPaneId: string | undefined;
         try {
-          const panes = await this.tmuxSessionManager.listPanes(
-            message.sessionId,
-            { activeWindowOnly: true },
-          );
-          const activePane = panes.find((pane) => pane.isActive);
-          if (activePane) {
-            targetPaneId = activePane.paneId;
+          if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+            const panes = await this.zellijSessionManager?.listPanes();
+            const activePane = panes?.find((pane) => pane.isFocused);
+            targetPaneId = activePane?.id;
+          } else {
+            const panes = await this.tmuxSessionManager.listPanes(
+              message.sessionId,
+              { activeWindowOnly: true },
+            );
+            const activePane = panes.find((pane) => pane.isActive);
+            if (activePane) {
+              targetPaneId = activePane.paneId;
+            }
           }
-        } catch {
-          // If we can't get panes, continue without a specific target
+        } catch (error) {
+          this.logger?.debug(
+            `[TerminalDashboard] Unable to resolve active pane for AI selector: ${error instanceof Error ? error.message : String(error)}`,
+          );
         }
         await this.showAiToolSelector(
           message.sessionId,
@@ -345,102 +488,172 @@ export class TerminalDashboardProvider
         return;
       case "createWindow":
         {
-          const panes = await this.tmuxSessionManager.listPanes(
-            message.sessionId,
-            {
-              activeWindowOnly: true,
-            },
-          );
-          const activePane = panes.find((pane) => pane.isActive) ?? panes[0];
-          const workspacePath =
-            vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-          await this.tmuxSessionManager.createWindow(
-            message.sessionId,
-            activePane?.currentPath ?? workspacePath,
-          );
+          const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+          if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+            await this.zellijSessionManager?.createTab({
+              workingDirectory: workspacePath,
+            });
+          } else {
+            const panes = await this.tmuxSessionManager.listPanes(
+              message.sessionId,
+              {
+                activeWindowOnly: true,
+              },
+            );
+            const activePane = panes.find((pane) => pane.isActive) ?? panes[0];
+            await this.tmuxSessionManager.createWindow(
+              message.sessionId,
+              activePane?.currentPath ?? workspacePath,
+            );
+          }
           await this.postSessionsToWebview();
         }
         return;
       case "nextWindow":
-        await this.tmuxSessionManager.nextWindow(message.sessionId);
+        if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+          await this.zellijSessionManager?.nextTab();
+        } else {
+          await this.tmuxSessionManager.nextWindow(message.sessionId);
+        }
         await this.postSessionsToWebview();
         return;
       case "prevWindow":
-        await this.tmuxSessionManager.prevWindow(message.sessionId);
+        if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+          await this.zellijSessionManager?.prevTab();
+        } else {
+          await this.tmuxSessionManager.prevWindow(message.sessionId);
+        }
         await this.postSessionsToWebview();
         return;
       case "killWindow":
-        await this.tmuxSessionManager.killWindow(message.windowId);
+        if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+          await this.zellijSessionManager?.killTab();
+        } else {
+          await this.tmuxSessionManager.killWindow(message.windowId);
+        }
         await this.postSessionsToWebview();
         return;
       case "selectWindow":
         this.logger?.debug(
           `[TerminalDashboard] selectWindow: sessionId=${message.sessionId}, windowId=${message.windowId}`,
         );
-        await this.tmuxSessionManager.selectWindow(message.windowId);
+        if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+          await this.zellijSessionManager?.selectTab(
+            this.parseZellijTabIndex(message.windowId),
+          );
+        } else {
+          await this.tmuxSessionManager.selectWindow(message.windowId);
+        }
         await this.postSessionsToWebview();
         return;
       case "switchPane":
-        await this.tmuxSessionManager.selectPane(
-          message.paneId,
-          message.windowId,
-        );
+        if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+          await this.zellijSessionManager?.selectPane(message.paneId);
+        } else {
+          await this.tmuxSessionManager.selectPane(
+            message.paneId,
+            message.windowId,
+          );
+        }
         await this.postSessionsToWebview();
         return;
       case "splitPane":
         {
-          const panes = await this.tmuxSessionManager.listPanes(
-            message.sessionId,
-          );
-          const activePane =
-            panes.find((pane) => pane.paneId === message.paneId) ??
-            panes.find((pane) => pane.isActive) ??
-            panes[0];
-          const targetPaneId =
-            activePane?.paneId ?? message.paneId ?? message.sessionId;
-          await this.tmuxSessionManager.splitPane(
-            targetPaneId,
-            message.direction,
-            {
-              workingDirectory: activePane?.currentPath,
-            },
-          );
+          if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+            if (message.paneId) {
+              await this.zellijSessionManager?.selectPane(message.paneId);
+            }
+            await this.zellijSessionManager?.splitPane(message.direction);
+          } else {
+            const panes = await this.tmuxSessionManager.listPanes(
+              message.sessionId,
+            );
+            const activePane =
+              panes.find((pane) => pane.paneId === message.paneId) ??
+              panes.find((pane) => pane.isActive) ??
+              panes[0];
+            const targetPaneId =
+              activePane?.paneId ?? message.paneId ?? message.sessionId;
+            await this.tmuxSessionManager.splitPane(
+              targetPaneId,
+              message.direction,
+              {
+                workingDirectory: activePane?.currentPath,
+              },
+            );
+          }
           await this.postSessionsToWebview();
         }
         return;
       case "splitPaneWithCommand":
         {
-          const panes = await this.tmuxSessionManager.listPanes(
-            message.sessionId,
-          );
-          const activePane =
-            panes.find((pane) => pane.paneId === message.paneId) ??
-            panes.find((pane) => pane.isActive) ??
-            panes[0];
-          await this.tmuxSessionManager.splitPane(
-            activePane?.paneId ?? message.paneId ?? message.sessionId,
-            message.direction,
-            {
+          if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+            if (message.paneId) {
+              await this.zellijSessionManager?.selectPane(message.paneId);
+            }
+            await this.zellijSessionManager?.splitPane(message.direction, {
               command: message.command,
-              workingDirectory: activePane?.currentPath,
-            },
-          );
+            });
+          } else {
+            const panes = await this.tmuxSessionManager.listPanes(
+              message.sessionId,
+            );
+            const activePane =
+              panes.find((pane) => pane.paneId === message.paneId) ??
+              panes.find((pane) => pane.isActive) ??
+              panes[0];
+            await this.tmuxSessionManager.splitPane(
+              activePane?.paneId ?? message.paneId ?? message.sessionId,
+              message.direction,
+              {
+                command: message.command,
+                workingDirectory: activePane?.currentPath,
+              },
+            );
+          }
           await this.postSessionsToWebview();
         }
         return;
       case "killPane":
-        await this.tmuxSessionManager.killPane(message.paneId);
+        if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+          if (message.paneId) {
+            await this.zellijSessionManager?.selectPane(message.paneId);
+          }
+          await this.zellijSessionManager?.killPane();
+        } else {
+          await this.tmuxSessionManager.killPane(message.paneId);
+        }
         await this.postSessionsToWebview();
         return;
       case "resizePane":
-        await this.tmuxSessionManager.resizePane(
-          message.paneId,
-          message.direction as "L" | "R" | "U" | "D",
-          message.amount,
-        );
+        if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+          const directionMap = {
+            L: "left",
+            R: "right",
+            U: "up",
+            D: "down",
+          } as const;
+          if (message.paneId) {
+            await this.zellijSessionManager?.selectPane(message.paneId);
+          }
+          await this.zellijSessionManager?.resizePane(
+            directionMap[message.direction as "L" | "R" | "U" | "D"],
+            message.amount,
+          );
+        } else {
+          await this.tmuxSessionManager.resizePane(
+            message.paneId,
+            message.direction as "L" | "R" | "U" | "D",
+            message.amount,
+          );
+        }
         await this.postSessionsToWebview();
         return;
       case "swapPane":
+        if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+          await this.postSessionsToWebview();
+          return;
+        }
         await this.tmuxSessionManager.swapPanes(
           message.sourcePaneId,
           message.targetPaneId,
@@ -464,29 +677,37 @@ export class TerminalDashboardProvider
         return;
       }
       case "killSession": {
-        const sessionsBefore = await this.tmuxSessionManager.discoverSessions();
+        const sessionBackend = await this.getSessionBackend(message.sessionId);
+        const sessionsBefore = await this.discoverDashboardSessions();
         const killedSession = sessionsBefore.find(
-          (s: TmuxDashboardSessionDto) => s.id === message.sessionId,
+          (s) => s.id === message.sessionId && s.backend === sessionBackend,
         );
         const wasActive = killedSession?.isActive ?? false;
         const killedWorkspace = killedSession?.workspace;
 
-        await vscode.commands.executeCommand(
-          "opencodeTui.killTmuxSession",
-          message.sessionId,
-        );
+        if (sessionBackend === "zellij" && this.terminalProvider) {
+          await this.terminalProvider.killTmuxSession(message.sessionId);
+        } else {
+          await vscode.commands.executeCommand(
+            "opencodeTui.killTmuxSession",
+            message.sessionId,
+          );
+        }
 
         if (wasActive && killedWorkspace) {
-          const sessionsAfter =
-            await this.tmuxSessionManager.discoverSessions();
+          const sessionsAfter = await this.discoverDashboardSessions();
           const nextSession = sessionsAfter.find(
-            (s: TmuxDashboardSessionDto) => s.workspace === killedWorkspace,
+            (s) => s.workspace === killedWorkspace && s.backend === sessionBackend,
           );
           if (nextSession) {
-            await vscode.commands.executeCommand(
-              "opencodeTui.switchTmuxSession",
-              nextSession.id,
-            );
+            if (sessionBackend === "zellij") {
+              await this.terminalProvider?.switchToZellijSession(nextSession.id);
+            } else {
+              await vscode.commands.executeCommand(
+                "opencodeTui.switchTmuxSession",
+                nextSession.id,
+              );
+            }
           }
         }
         await this.postSessionsToWebview();
@@ -722,7 +943,7 @@ export class TerminalDashboardProvider
 
     this.subscriptions.push(
       webview.onDidReceiveMessage((message) => {
-        void this.handleWebviewMessage(message as TmuxDashboardActionMessage);
+        return this.handleWebviewMessage(message as TmuxDashboardActionMessage);
       }),
     );
 

--- a/src/providers/TerminalProvider.test.ts
+++ b/src/providers/TerminalProvider.test.ts
@@ -1470,6 +1470,7 @@ describe("TerminalProvider", () => {
       type: "activeSession",
       sessionName: "tmux-selected",
       sessionId: "tmux-selected",
+      backend: "tmux",
     });
   });
 

--- a/src/providers/TerminalProvider.test.ts
+++ b/src/providers/TerminalProvider.test.ts
@@ -398,7 +398,7 @@ describe("TerminalProvider", () => {
     );
   });
 
-  it("formats editor references through the active tool operator", async () => {
+  it("formats editor references with the active tool", async () => {
     mockConfiguration({
       autoStartOnOpen: false,
       enableHttpApi: false,

--- a/src/providers/TerminalProvider.test.ts
+++ b/src/providers/TerminalProvider.test.ts
@@ -57,8 +57,6 @@ describe("TerminalProvider", () => {
     enableHttpApi?: boolean;
     defaultAiTool?: string;
     aiTools?: readonly unknown[];
-    nativeShellDefault?: string;
-    tmuxSessionDefault?: string;
     collapseSecondaryBarOnEditorOpen?: boolean;
   }) {
     const {
@@ -66,8 +64,6 @@ describe("TerminalProvider", () => {
       enableHttpApi = false,
       defaultAiTool = "opencode",
       aiTools = DEFAULT_AI_TOOLS,
-      nativeShellDefault = "",
-      tmuxSessionDefault = "",
       collapseSecondaryBarOnEditorOpen = false,
     } = options ?? {};
 
@@ -90,12 +86,6 @@ describe("TerminalProvider", () => {
         }
         if (key === "logLevel") {
           return "error";
-        }
-        if (key === "nativeShellDefault") {
-          return nativeShellDefault;
-        }
-        if (key === "tmuxSessionDefault") {
-          return tmuxSessionDefault;
         }
         if (key === "collapseSecondaryBarOnEditorOpen") {
           return collapseSecondaryBarOnEditorOpen;
@@ -538,7 +528,6 @@ describe("TerminalProvider", () => {
     mockConfiguration({
       autoStartOnOpen: false,
       enableHttpApi: false,
-      nativeShellDefault: "shell",
     });
     const instanceStore = new InstanceStore();
     instanceStore.upsert({

--- a/src/providers/TerminalProvider.test.ts
+++ b/src/providers/TerminalProvider.test.ts
@@ -115,6 +115,7 @@ describe("TerminalProvider", () => {
   function createProvider(options?: {
     instanceStore?: InstanceStore;
     tmuxSessionManager?: TmuxSessionManager;
+    zellijSessionManager?: any;
   }): TerminalProvider {
     const context = new vscode.ExtensionContext();
     const portManager = new PortManager();
@@ -125,6 +126,7 @@ describe("TerminalProvider", () => {
       portManager,
       options?.instanceStore,
       options?.tmuxSessionManager,
+      options?.zellijSessionManager,
     );
   }
 
@@ -396,6 +398,7 @@ describe("TerminalProvider", () => {
 
     provider = createProvider({ instanceStore, tmuxSessionManager });
     resolveProvider(provider);
+    vi.spyOn((provider as any).sessionRuntime, "getActiveBackend").mockReturnValue("tmux");
 
     await provider.launchAiTool("tmux-codex", "codex", true);
 
@@ -1154,6 +1157,7 @@ describe("TerminalProvider", () => {
     } as unknown as TmuxSessionManager;
 
     provider = createProvider({ instanceStore, tmuxSessionManager });
+    vi.spyOn((provider as any).sessionRuntime, "getActiveBackend").mockReturnValue("tmux");
 
     await provider.launchAiTool("repo-launch", "codex", true);
 
@@ -1192,6 +1196,7 @@ describe("TerminalProvider", () => {
     } as unknown as TmuxSessionManager;
 
     provider = createProvider({ instanceStore, tmuxSessionManager });
+    vi.spyOn((provider as any).sessionRuntime, "getActiveBackend").mockReturnValue("tmux");
 
     await provider.launchAiTool("repo-direct-pane", "opencode", false, "%77");
 
@@ -1247,6 +1252,7 @@ describe("TerminalProvider", () => {
     } as unknown as TmuxSessionManager;
 
     provider = createProvider({ tmuxSessionManager });
+    vi.spyOn((provider as any).sessionRuntime, "getActiveBackend").mockReturnValue("tmux");
     const warnSpy = vi.spyOn((provider as any).logger, "warn");
 
     await provider.launchAiTool("repo-no-pane", "codex", false);
@@ -1265,12 +1271,42 @@ describe("TerminalProvider", () => {
     } as unknown as TmuxSessionManager;
 
     provider = createProvider({ tmuxSessionManager });
+    vi.spyOn((provider as any).sessionRuntime, "getActiveBackend").mockReturnValue("tmux");
     const warnSpy = vi.spyOn((provider as any).logger, "warn");
 
     await provider.launchAiTool("repo-launch-error", "codex", false);
 
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("Failed to launch AI tool: tmux unavailable"),
+    );
+  });
+
+  it("launches AI tool against zellij focused pane when zellij backend active", async () => {
+    mockConfiguration();
+    const zellijSelectPane = vi.fn().mockResolvedValue(undefined);
+    const zellijSendTextToPane = vi.fn().mockResolvedValue(undefined);
+    const zellijSessionManager = {
+      isAvailable: vi.fn().mockResolvedValue(true),
+      selectPane: zellijSelectPane,
+      sendTextToPane: zellijSendTextToPane,
+    } as any;
+
+    provider = createProvider({ zellijSessionManager });
+    vi.spyOn((provider as any).sessionRuntime, "getActiveBackend").mockReturnValue("zellij");
+
+    await provider.launchAiTool("zellij-session", "codex", false, "terminal_5");
+
+    expect(zellijSelectPane).toHaveBeenCalledWith("terminal_5");
+    expect(zellijSendTextToPane).toHaveBeenCalledWith("codex", { submit: true });
+  });
+
+  it("executeRawTmuxCommand rejects when active backend is not tmux", async () => {
+    mockConfiguration();
+    provider = createProvider();
+    vi.spyOn((provider as any).sessionRuntime, "getActiveBackend").mockReturnValue("zellij");
+
+    await expect(provider.executeRawTmuxCommand("rename-session")).rejects.toThrow(
+      /only supported on the tmux backend/i,
     );
   });
 
@@ -1625,6 +1661,7 @@ describe("TerminalProvider", () => {
       instanceStore: activeStore,
       tmuxSessionManager: rawTmuxManager,
     });
+    vi.spyOn((provider as any).sessionRuntime, "getActiveBackend").mockReturnValue("tmux");
     vi.mocked(vscode.window.showInputBox).mockResolvedValueOnce(
       "renamed-session",
     );

--- a/src/providers/TerminalProvider.ts
+++ b/src/providers/TerminalProvider.ts
@@ -12,6 +12,7 @@ import {
   AiToolConfig,
   HostMessage,
   TMUX_RAW_ALLOWED_SUBCOMMANDS,
+  TerminalBackendType,
   resolveAiToolConfigs,
 } from "../types";
 import type { TmuxRawSubcommand } from "../types";
@@ -19,6 +20,8 @@ import { AiToolOperatorRegistry } from "../services/aiTools/AiToolOperatorRegist
 import { MessageRouter, MessageRouterProviderBridge } from "./MessageRouter";
 import { SessionRuntime } from "./SessionRuntime";
 import { renderTerminalHtml } from "../webview/terminal/html";
+import { ZellijSessionManager } from "../services/ZellijSessionManager";
+import { TerminalBackendRegistry } from "../services/terminalBackends";
 
 export class TerminalProvider
   implements vscode.WebviewViewProvider, vscode.WebviewPanelSerializer
@@ -41,6 +44,12 @@ export class TerminalProvider
     private readonly portManager: PortManager,
     private readonly instanceStore?: InstanceStore,
     private readonly tmuxSessionManager?: TmuxSessionManager,
+    private readonly zellijSessionManager?: ZellijSessionManager,
+    private readonly backendRegistry: TerminalBackendRegistry = new TerminalBackendRegistry([
+      { type: "native", label: "Native", isAvailable: () => true },
+      { type: "tmux", label: "Tmux", isAvailable: () => !!tmuxSessionManager },
+      { type: "zellij", label: "Zellij", isAvailable: () => !!zellijSessionManager },
+    ]),
   ) {
     this.contextSharingService = new ContextSharingService();
     this.aiToolRegistry = new AiToolOperatorRegistry();
@@ -51,6 +60,8 @@ export class TerminalProvider
       undefined,
       this.portManager,
       this.tmuxSessionManager,
+      this.zellijSessionManager,
+      this.backendRegistry,
       this.instanceStore,
       this.logger,
       this.contextSharingService,
@@ -75,6 +86,8 @@ export class TerminalProvider
       toggleEditorAttachment: () => this.toggleEditorAttachment(),
       restart: () => this.restart(),
       switchToNativeShell: () => this.switchToNativeShell(),
+      selectTerminalBackend: (backend) => this.selectTerminalBackend(backend),
+      cycleTerminalBackend: () => this.cycleTerminalBackend(),
       pasteText: (text) => this.pasteText(text),
       getActiveInstanceId: () => this.getActiveInstanceId(),
       setLastKnownTerminalSize: (cols, rows) =>
@@ -107,6 +120,9 @@ export class TerminalProvider
       zoomTmuxPane: () => this.zoomTmuxPane(),
       getSelectedTmuxSessionId: () => this.getSelectedTmuxSessionId(),
       isTmuxAvailable: () => !!this.tmuxSessionManager,
+      isZellijAvailable: () => !!this.zellijSessionManager,
+      getActiveBackend: () => this.sessionRuntime.getActiveBackend(),
+      getBackendAvailability: () => this.sessionRuntime.getBackendAvailability(),
     };
 
     this.messageRouter = new MessageRouter(
@@ -322,6 +338,16 @@ export class TerminalProvider
 
   public async switchToNativeShell(): Promise<void> {
     await this.sessionRuntime.switchToNativeShell();
+  }
+
+  public async selectTerminalBackend(
+    backend: TerminalBackendType,
+  ): Promise<void> {
+    await this.sessionRuntime.selectTerminalBackend(backend);
+  }
+
+  public async cycleTerminalBackend(): Promise<void> {
+    await this.sessionRuntime.cycleTerminalBackend();
   }
 
   public async createTmuxSession(): Promise<string | undefined> {
@@ -566,18 +592,31 @@ export class TerminalProvider
       this.sessionRuntime.resolveTmuxSessionIdForInstance(
         this.getActiveInstanceId(),
       );
-    const sessionId = selectedSessionId ?? resolvedSessionId;
+    const activeBackend = this.sessionRuntime.getActiveBackend();
+    const zellijSessionId = this.sessionRuntime.resolveZellijSessionIdForInstance(
+      this.getActiveInstanceId(),
+    );
+    const sessionId =
+      activeBackend === "zellij"
+        ? zellijSessionId
+        : selectedSessionId ?? resolvedSessionId;
+    const sessionBackend: TerminalBackendType = zellijSessionId
+      ? "zellij"
+      : sessionId
+        ? "tmux"
+        : "native";
 
     if (sessionId) {
       webview.postMessage({
         type: "activeSession",
         sessionName: sessionId,
         sessionId,
+        backend: sessionBackend,
       });
       return;
     }
 
-    webview.postMessage({ type: "activeSession" });
+    webview.postMessage({ type: "activeSession", backend: "native" });
   }
 
   private getEditorPanelOptions(): vscode.WebviewOptions &

--- a/src/providers/TerminalProvider.ts
+++ b/src/providers/TerminalProvider.ts
@@ -83,6 +83,7 @@ export class TerminalProvider
       isStarted: () => this.isStarted(),
       resizeActiveTerminal: (cols, rows) =>
         this.resizeActiveTerminal(cols, rows),
+      getActiveTerminalId: () => this.activeTerminalId,
       postWebviewMessage: (message) => this.postWebviewMessage(message),
       routeDroppedTextToTmuxPane: (text, dropCell) =>
         this.sessionRuntime.routeDroppedTextToTmuxPane(text, dropCell),
@@ -122,6 +123,10 @@ export class TerminalProvider
 
   private get activeInstanceId(): InstanceId {
     return this.sessionRuntime.getActiveInstanceId();
+  }
+
+  private get activeTerminalId(): string {
+    return this.sessionRuntime.getActiveTerminalId();
   }
 
   public get lastKnownCols(): number {
@@ -373,7 +378,7 @@ export class TerminalProvider
       }
     }
 
-    this.terminalManager.writeToTerminal(this.activeInstanceId, prompt);
+    this.terminalManager.writeToTerminal(this.activeTerminalId, prompt);
   }
 
   public async launchAiTool(
@@ -531,7 +536,7 @@ export class TerminalProvider
   }
 
   private resizeActiveTerminal(cols: number, rows: number): void {
-    this.terminalManager.resizeTerminal(this.activeInstanceId, cols, rows);
+    this.terminalManager.resizeTerminal(this.activeTerminalId, cols, rows);
   }
 
   private getActiveInstanceId(): InstanceId {

--- a/src/providers/TerminalProvider.ts
+++ b/src/providers/TerminalProvider.ts
@@ -80,6 +80,7 @@ export class TerminalProvider
     const routerBridge: MessageRouterProviderBridge = {
       startOpenCode: () => this.startOpenCode(),
       switchToTmuxSession: (sessionId) => this.switchToTmuxSession(sessionId),
+      switchToZellijSession: (sessionId) => this.switchToZellijSession(sessionId),
       killTmuxSession: (sessionId) => this.killTmuxSession(sessionId),
       createTmuxSession: () => this.createTmuxSession(),
       toggleDashboard: () => this.toggleDashboard(),
@@ -330,6 +331,10 @@ export class TerminalProvider
 
   public async switchToTmuxSession(sessionId: string): Promise<void> {
     await this.sessionRuntime.switchToTmuxSession(sessionId);
+  }
+
+  public async switchToZellijSession(sessionId: string): Promise<void> {
+    await this.sessionRuntime.switchToZellijSession(sessionId);
   }
 
   public resolveInstanceIdFromSessionId(sessionId: string): InstanceId {

--- a/src/providers/TerminalProvider.ts
+++ b/src/providers/TerminalProvider.ts
@@ -386,7 +386,7 @@ export class TerminalProvider
     }
 
     const resolvedArgs = await this.resolveRawTmuxCommandArgs(subcommand, args);
-    return await this.tmuxSessionManager.executeRawCommand(
+    return this.tmuxSessionManager.executeRawCommand(
       sessionId,
       subcommand,
       resolvedArgs,
@@ -512,19 +512,19 @@ export class TerminalProvider
   ): Promise<string[]> {
     switch (subcommand) {
       case "rename-session":
-        return await this.promptForTmuxValue(
+        return this.promptForTmuxValue(
           "Rename tmux session",
           "Enter the new tmux session name",
           args[0],
         );
       case "rename-window":
-        return await this.promptForTmuxValue(
+        return this.promptForTmuxValue(
           "Rename tmux window",
           "Enter the new tmux window name",
           args[0],
         );
       case "select-layout":
-        return await this.promptForTmuxValue(
+        return this.promptForTmuxValue(
           "Select tmux layout",
           "Enter a tmux layout name (e.g. even-horizontal, tiled, main-vertical)",
           args[0],

--- a/src/providers/TerminalProvider.ts
+++ b/src/providers/TerminalProvider.ts
@@ -367,6 +367,11 @@ export class TerminalProvider
     subcommand: string,
     args: string[] = [],
   ): Promise<string> {
+    if (this.sessionRuntime.getActiveBackend() !== "tmux") {
+      throw new Error(
+        "Raw tmux subcommands are only supported on the tmux backend",
+      );
+    }
     if (!this.tmuxSessionManager) {
       throw new Error("tmux session manager unavailable");
     }
@@ -427,10 +432,6 @@ export class TerminalProvider
       );
     }
 
-    if (!this.tmuxSessionManager) {
-      return;
-    }
-
     const tool = this.sessionRuntime.resolveToolByName(toolName);
     if (!tool) {
       return;
@@ -440,11 +441,37 @@ export class TerminalProvider
       this.sessionRuntime.resolveInstanceIdFromSessionId(sessionId);
     this.sessionRuntime.rememberSelectedTool(tool.name, instanceId);
 
-    const effectiveSessionId =
-      this.sessionRuntime.resolveTmuxSessionIdForInstance(instanceId) ??
-      sessionId;
+    const operator = this.aiToolRegistry.getForConfig(tool);
+    const launchCommand = operator.getLaunchCommand(tool);
+    const activeBackend = this.sessionRuntime.getActiveBackend();
 
     try {
+      if (activeBackend === "zellij") {
+        if (!this.zellijSessionManager) {
+          this.logger.warn(
+            "[TerminalProvider] launchAiTool skipped: zellij manager unavailable",
+          );
+          return;
+        }
+        if (targetPaneId) {
+          await this.zellijSessionManager.selectPane(targetPaneId);
+        }
+        await this.zellijSessionManager.sendTextToPane(launchCommand, {
+          submit: true,
+        });
+        return;
+      }
+
+      if (activeBackend !== "tmux" || !this.tmuxSessionManager) {
+        this.logger.warn(
+          `[TerminalProvider] launchAiTool skipped: backend ${activeBackend} does not support pane targeting`,
+        );
+        return;
+      }
+
+      const effectiveSessionId =
+        this.sessionRuntime.resolveTmuxSessionIdForInstance(instanceId) ??
+        sessionId;
       let paneIdToUse: string | undefined = targetPaneId;
       if (!paneIdToUse) {
         const panes = await this.tmuxSessionManager.listPanes(
@@ -455,10 +482,9 @@ export class TerminalProvider
         paneIdToUse = targetPane?.paneId;
       }
       if (paneIdToUse) {
-        const operator = this.aiToolRegistry.getForConfig(tool);
         await this.tmuxSessionManager.sendTextToPane(
           paneIdToUse,
-          operator.getLaunchCommand(tool),
+          launchCommand,
         );
       } else {
         this.logger.warn(

--- a/src/services/InstanceStore.ts
+++ b/src/services/InstanceStore.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import * as vscode from "vscode";
+import { TerminalBackendType } from "../types";
 
 export type InstanceId = string;
 
@@ -27,6 +28,8 @@ interface InstanceRuntime {
   pid?: number;
   terminalKey?: string;
   tmuxSessionId?: string;
+  zellijSessionId?: string;
+  terminalBackend?: TerminalBackendType;
   lastSeenAt?: number;
 }
 

--- a/src/services/ZellijSessionManager.test.ts
+++ b/src/services/ZellijSessionManager.test.ts
@@ -312,7 +312,6 @@ describe("ZellijSessionManager", () => {
     expect(execCalls[0]?.args).toEqual([
       "action",
       "dump-screen",
-      "/dev/stdout",
     ]);
   });
 

--- a/src/services/ZellijSessionManager.test.ts
+++ b/src/services/ZellijSessionManager.test.ts
@@ -247,11 +247,17 @@ describe("ZellijSessionManager", () => {
     expect(execCalls[0]?.cwd).toBe("/tmp/repo");
   });
 
-  it("parses tab-separated tab output", async () => {
-    mockExecSequence([{ stdout: "1\tmain\ttrue\n2\ttests\tfalse\n" }]);
+  it("parses zellij action list-tabs columnar output", async () => {
+    // Real zellij 0.44.1 output: 'TAB_ID  POSITION  NAME'
+    mockExecSequence([
+      {
+        stdout: "TAB_ID  POSITION  NAME\n0  0  main\n1  1  tests\n",
+      },
+    ]);
 
+    // POSITION 0 → display index 1, POSITION 1 → display index 2
     await expect(manager.listTabs()).resolves.toEqual([
-      { index: 1, name: "main", isActive: true },
+      { index: 1, name: "main", isActive: false },
       { index: 2, name: "tests", isActive: false },
     ]);
   });

--- a/src/services/ZellijSessionManager.test.ts
+++ b/src/services/ZellijSessionManager.test.ts
@@ -4,7 +4,7 @@ import { ZellijSessionManager } from "./ZellijSessionManager";
 type MockExecStep = {
   stdout?: string;
   stderr?: string;
-  error?: (Error & { code?: number | string }) | null;
+  error?: (Error & { code?: number | string; stderr?: string }) | null;
 };
 
 describe("ZellijSessionManager", () => {
@@ -71,5 +71,249 @@ describe("ZellijSessionManager", () => {
 
   it("builds attach command", () => {
     expect(manager.getAttachCommand("repo-a")).toBe("zellij attach 'repo-a'");
+  });
+
+  it("kills a named session", async () => {
+    mockExecSequence([{ stdout: "" }]);
+
+    await expect(manager.killSession("repo-a")).resolves.toBeUndefined();
+
+    expect(execCalls[0]?.args).toEqual(["kill-session", "repo-a"]);
+  });
+
+  it("switches sessions by name", async () => {
+    mockExecSequence([{ stdout: "" }]);
+
+    await expect(manager.switchSession("repo-b")).resolves.toBeUndefined();
+
+    expect(execCalls[0]?.args).toEqual(["action", "switch-session", "repo-b"]);
+  });
+
+  it("splits panes horizontally and returns the new pane id", async () => {
+    mockExecSequence([{ stdout: "terminal_7\n" }]);
+
+    await expect(
+      manager.splitPane("h", {
+        command: "npm test",
+        workingDirectory: "/workspace/repo-a",
+      }),
+    ).resolves.toBe("terminal_7");
+
+    expect(execCalls[0]).toEqual({
+      file: "zellij",
+      args: [
+        "action",
+        "new-pane",
+        "--direction",
+        "right",
+        "--cwd",
+        "/workspace/repo-a",
+        "--command",
+        "npm test",
+      ],
+      cwd: "/workspace/repo-a",
+    });
+  });
+
+  it("splits panes vertically", async () => {
+    mockExecSequence([{ stdout: "plugin_2\n" }]);
+
+    await expect(manager.splitPane("v")).resolves.toBe("plugin_2");
+
+    expect(execCalls[0]?.args).toEqual([
+      "action",
+      "new-pane",
+      "--direction",
+      "down",
+    ]);
+  });
+
+  it("throws when split pane output has no pane id", async () => {
+    mockExecSequence([{ stdout: "" }]);
+
+    await expect(manager.splitPane("h")).rejects.toThrow(
+      "Failed to get pane ID",
+    );
+  });
+
+  it("closes, focuses, resizes, and zooms panes", async () => {
+    mockExecSequence([
+      { stdout: "" },
+      { stdout: "" },
+      { stdout: "" },
+      { stdout: "" },
+    ]);
+
+    await manager.killPane();
+    await manager.selectPane("terminal_1");
+    await manager.resizePane("left", 5);
+    await manager.zoomPane();
+
+    expect(execCalls.map((call) => call.args)).toEqual([
+      ["action", "close-pane"],
+      ["action", "focus-pane-id", "terminal_1"],
+      ["action", "resize", "--left", "+5"],
+      ["action", "toggle-fullscreen"],
+    ]);
+  });
+
+  it("formats negative resize adjustments", async () => {
+    mockExecSequence([{ stdout: "" }]);
+
+    await manager.resizePane("up", -3);
+
+    expect(execCalls[0]?.args).toEqual(["action", "resize", "--up", "-3"]);
+  });
+
+  it("sends text and optionally submits Enter", async () => {
+    mockExecSequence([{ stdout: "" }, { stdout: "" }, { stdout: "" }]);
+
+    await manager.sendTextToPane("hello");
+    await manager.sendTextToPane("run", { submit: true });
+
+    expect(execCalls.map((call) => call.args)).toEqual([
+      ["action", "write-chars", "hello"],
+      ["action", "write-chars", "run"],
+      ["action", "send-keys", "Enter"],
+    ]);
+  });
+
+  it("parses tab-separated pane output", async () => {
+    mockExecSequence([
+      {
+        stdout:
+          "terminal_1\nterminal_2\tserver\tfocused=true\tfloating=true\nplugin_3\tlogs\tfocused=false\n",
+      },
+    ]);
+
+    await expect(manager.listPanes()).resolves.toEqual([
+      { id: "terminal_1", title: "", isFocused: false, isFloating: false },
+      { id: "terminal_2", title: "server", isFocused: true, isFloating: true },
+      { id: "plugin_3", title: "logs", isFocused: false, isFloating: false },
+    ]);
+  });
+
+  it("parses JSON pane output", async () => {
+    mockExecSequence([
+      {
+        stdout: JSON.stringify([
+          { id: "terminal_1", title: "shell", is_focused: true },
+          { id: "plugin_2", name: "status", is_floating: true },
+        ]),
+      },
+    ]);
+
+    await expect(manager.listPanes()).resolves.toEqual([
+      { id: "terminal_1", title: "shell", isFocused: true, isFloating: false },
+      { id: "plugin_2", title: "status", isFocused: false, isFloating: true },
+    ]);
+  });
+
+  it("returns empty panes for no-session errors", async () => {
+    const error = Object.assign(new Error("command failed"), {
+      code: 1,
+      stderr: "There is no active session!",
+    });
+    mockExecSequence([{ error }]);
+
+    await expect(manager.listPanes()).resolves.toEqual([]);
+  });
+
+  it("creates and navigates tabs", async () => {
+    mockExecSequence([
+      { stdout: "" },
+      { stdout: "" },
+      { stdout: "" },
+      { stdout: "" },
+      { stdout: "" },
+      { stdout: "" },
+    ]);
+
+    await manager.createTab({ name: "tests", workingDirectory: "/tmp/repo" });
+    await manager.nextTab();
+    await manager.prevTab();
+    await manager.killTab();
+    await manager.selectTab(2);
+    await manager.renameTab("server");
+
+    expect(execCalls.map((call) => call.args)).toEqual([
+      ["action", "new-tab", "--name", "tests", "--cwd", "/tmp/repo"],
+      ["action", "go-to-next-tab"],
+      ["action", "go-to-previous-tab"],
+      ["action", "close-tab"],
+      ["action", "go-to-tab", "2"],
+      ["action", "rename-tab", "server"],
+    ]);
+    expect(execCalls[0]?.cwd).toBe("/tmp/repo");
+  });
+
+  it("parses tab-separated tab output", async () => {
+    mockExecSequence([{ stdout: "1\tmain\ttrue\n2\ttests\tfalse\n" }]);
+
+    await expect(manager.listTabs()).resolves.toEqual([
+      { index: 1, name: "main", isActive: true },
+      { index: 2, name: "tests", isActive: false },
+    ]);
+  });
+
+  it("parses human-readable tab output", async () => {
+    mockExecSequence([{ stdout: "1: main (active)\n2: tests\n" }]);
+
+    await expect(manager.listTabs()).resolves.toEqual([
+      { index: 1, name: "main", isActive: true },
+      { index: 2, name: "tests", isActive: false },
+    ]);
+  });
+
+  it("parses JSON tab output", async () => {
+    mockExecSequence([
+      {
+        stdout: JSON.stringify([
+          { index: 1, name: "main", active: true },
+          { index: 2, title: "logs", is_active: false },
+        ]),
+      },
+    ]);
+
+    await expect(manager.listTabs()).resolves.toEqual([
+      { index: 1, name: "main", isActive: true },
+      { index: 2, name: "logs", isActive: false },
+    ]);
+  });
+
+  it("returns active focus from current tab info and focused pane", async () => {
+    mockExecSequence([
+      { stdout: "name: main\n" },
+      { stdout: "terminal_1\tone\nterminal_2\ttwo\tfocused=true\n" },
+    ]);
+
+    await expect(manager.getActiveFocus()).resolves.toEqual({
+      tabName: "main",
+      paneId: "terminal_2",
+    });
+  });
+
+  it("returns undefined active focus when no focused pane exists", async () => {
+    mockExecSequence([{ stdout: "name: main\n" }, { stdout: "terminal_1\tone\n" }]);
+
+    await expect(manager.getActiveFocus()).resolves.toBeUndefined();
+  });
+
+  it("dumps focused pane screen content", async () => {
+    mockExecSequence([{ stdout: "screen\ncontent\n" }]);
+
+    await expect(manager.dumpScreen()).resolves.toBe("screen\ncontent\n");
+    expect(execCalls[0]?.args).toEqual([
+      "action",
+      "dump-screen",
+      "/dev/stdout",
+    ]);
+  });
+
+  it("returns an empty screen for no-session dump errors", async () => {
+    const error = Object.assign(new Error("no sessions"), { code: 1 });
+    mockExecSequence([{ error }]);
+
+    await expect(manager.dumpScreen()).resolves.toBe("");
   });
 });

--- a/src/services/ZellijSessionManager.test.ts
+++ b/src/services/ZellijSessionManager.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ZellijSessionManager } from "./ZellijSessionManager";
+
+type MockExecStep = {
+  stdout?: string;
+  stderr?: string;
+  error?: (Error & { code?: number | string }) | null;
+};
+
+describe("ZellijSessionManager", () => {
+  let manager: ZellijSessionManager;
+  let execCalls: Array<{ file: string; args: string[]; cwd?: string }>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    execCalls = [];
+    manager = new ZellijSessionManager();
+  });
+
+  function mockExecSequence(steps: MockExecStep[]): void {
+    let callIndex = 0;
+    manager = new ZellijSessionManager(undefined, (file, args, options, callback) => {
+      execCalls.push({ file, args, cwd: options.cwd?.toString() });
+      const step = steps[callIndex++] ?? { stdout: "", stderr: "" };
+      callback(step.error ?? null, step.stdout ?? "", step.stderr ?? "");
+    });
+  }
+
+  it("reports available when zellij version command succeeds", async () => {
+    mockExecSequence([{ stdout: "zellij 0.41.2" }]);
+
+    await expect(manager.isAvailable()).resolves.toBe(true);
+    expect(execCalls[0]?.args).toEqual(["--version"]);
+  });
+
+  it("reports unavailable when zellij binary is missing", async () => {
+    const missingZellijError = Object.assign(new Error("spawn zellij ENOENT"), {
+      code: "ENOENT",
+    });
+    mockExecSequence([{ error: missingZellijError }]);
+
+    await expect(manager.isAvailable()).resolves.toBe(false);
+  });
+
+  it("parses zellij sessions", async () => {
+    mockExecSequence([{ stdout: "repo-a\nrepo-b (current)\n" }]);
+
+    await expect(manager.discoverSessions()).resolves.toEqual([
+      { id: "repo-a", name: "repo-a", workspace: "repo-a", isActive: false },
+      { id: "repo-b", name: "repo-b", workspace: "repo-b", isActive: true },
+    ]);
+  });
+
+  it("creates missing sessions with create-background attach", async () => {
+    mockExecSequence([{ stdout: "" }, { stdout: "" }]);
+
+    await expect(
+      manager.ensureSession("repo-a", "/workspace/repo-a"),
+    ).resolves.toMatchObject({
+      action: "created",
+      session: { id: "repo-a" },
+    });
+
+    expect(execCalls[1]?.args).toEqual([
+      "attach",
+      "--create-background",
+      "repo-a",
+    ]);
+    expect(execCalls[1]?.cwd).toBe("/workspace/repo-a");
+  });
+
+  it("builds attach command", () => {
+    expect(manager.getAttachCommand("repo-a")).toBe("zellij attach 'repo-a'");
+  });
+});

--- a/src/services/ZellijSessionManager.ts
+++ b/src/services/ZellijSessionManager.ts
@@ -52,7 +52,7 @@ export interface ZellijTab {
 
 export class ZellijSessionManager {
   public constructor(
-    _logger?: ILogger,
+    private readonly logger?: ILogger,
     private readonly runExecFile: ExecFileLike = (
       file,
       args,
@@ -348,15 +348,17 @@ export class ZellijSessionManager {
         return undefined;
       }
       return { tabName, paneId: focusedPane.id };
-    } catch {
+    } catch (error) {
+      this.logger?.debug(
+        `[ZellijSessionManager] getActiveFocus failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
       return undefined;
     }
   }
-
   /** Dump screen content of focused pane */
   public async dumpScreen(): Promise<string> {
     try {
-      return await this.runZellij(["action", "dump-screen", "/dev/stdout"]);
+      return await this.runZellij(["action", "dump-screen"]);
     } catch (error) {
       if (this.isZellijUnavailable(error)) {
         throw new ZellijUnavailableError();
@@ -536,11 +538,13 @@ export class ZellijSessionManager {
     }
     try {
       return JSON.parse(trimmed);
-    } catch {
+    } catch (error) {
+      this.logger?.debug(
+        `[ZellijSessionManager] tryParseJson failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
       return undefined;
     }
   }
-
   private isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null && !Array.isArray(value);
   }

--- a/src/services/ZellijSessionManager.ts
+++ b/src/services/ZellijSessionManager.ts
@@ -1,0 +1,192 @@
+import {
+  execFile,
+  type ExecFileException,
+  type ExecFileOptionsWithStringEncoding,
+} from "node:child_process";
+import { basename } from "node:path";
+import { TmuxSession } from "../types";
+import { ILogger } from "./ILogger";
+
+interface ExecError extends Error {
+  code?: number | string | null;
+  stderr?: string;
+}
+
+type ExecFileCallback = (
+  error: ExecFileException | null,
+  stdout: string,
+  stderr: string,
+) => void;
+
+type ExecFileLike = (
+  file: string,
+  args: string[],
+  options: ExecFileOptionsWithStringEncoding,
+  callback: ExecFileCallback,
+) => void;
+
+export class ZellijUnavailableError extends Error {
+  constructor(message: string = "zellij is not installed") {
+    super(message);
+    this.name = "ZellijUnavailableError";
+  }
+}
+
+interface EnsureZellijSessionResult {
+  action: "attached" | "created";
+  session: TmuxSession;
+}
+
+export class ZellijSessionManager {
+  public constructor(
+    _logger?: ILogger,
+    private readonly runExecFile: ExecFileLike = (
+      file,
+      args,
+      options,
+      callback,
+    ) => {
+      execFile(file, args, options, callback);
+    },
+  ) {}
+
+  public async isAvailable(): Promise<boolean> {
+    try {
+      await this.runZellij(["--version"]);
+      return true;
+    } catch (error) {
+      if (this.isZellijUnavailable(error)) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  public async discoverSessions(): Promise<TmuxSession[]> {
+    try {
+      const stdout = await this.runZellij(["list-sessions"]);
+      return this.parseSessions(stdout);
+    } catch (error) {
+      if (this.isNoSessionsError(error)) {
+        return [];
+      }
+      if (this.isZellijUnavailable(error)) {
+        throw new ZellijUnavailableError();
+      }
+      throw error;
+    }
+  }
+
+  public async ensureSession(
+    sessionName: string,
+    workspacePath: string,
+  ): Promise<EnsureZellijSessionResult> {
+    const sessions = await this.discoverSessions();
+    const existing = sessions.find((session) => session.id === sessionName);
+    if (existing) {
+      return { action: "attached", session: { ...existing, isActive: true } };
+    }
+
+    const existingIds = new Set(sessions.map((session) => session.id));
+    const resolvedName = this.resolveCollisionSafeSessionName(
+      sessionName,
+      existingIds,
+    );
+    await this.createSession(resolvedName, workspacePath);
+    return {
+      action: "created",
+      session: {
+        id: resolvedName,
+        name: resolvedName,
+        workspace: basename(workspacePath) || resolvedName,
+        isActive: true,
+      },
+    };
+  }
+
+  public async createSession(
+    sessionName: string,
+    workspacePath: string,
+  ): Promise<void> {
+    try {
+      await this.runZellij(
+        ["attach", "--create-background", sessionName],
+        workspacePath,
+      );
+    } catch (error) {
+      if (this.isZellijUnavailable(error)) {
+        throw new ZellijUnavailableError();
+      }
+      throw error;
+    }
+  }
+
+  public getAttachCommand(sessionName: string): string {
+    return `zellij attach ${this.shellQuote(sessionName)}`;
+  }
+
+  private parseSessions(stdout: string): TmuxSession[] {
+    return stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const name = line.split(/\s+/)[0] ?? line;
+        return {
+          id: name,
+          name,
+          workspace: name,
+          isActive: /\(current\)|\[current\]/i.test(line),
+        };
+      });
+  }
+
+  private async runZellij(args: string[], cwd?: string): Promise<string> {
+    return await new Promise<string>((resolve, reject) => {
+      this.runExecFile("zellij", args, cwd ? { cwd } : {}, (error, stdout, stderr) => {
+        if (error) {
+          reject(Object.assign(error, { stderr }));
+          return;
+        }
+        resolve(stdout);
+      });
+    });
+  }
+
+  private isNoSessionsError(error: unknown): boolean {
+    if (!(error instanceof Error)) {
+      return false;
+    }
+    const stderr = (error as ExecError).stderr ?? "";
+    return /no sessions|not found/i.test(stderr) || /no sessions/i.test(error.message);
+  }
+
+  private isZellijUnavailable(error: unknown): boolean {
+    if (!(error instanceof Error)) {
+      return false;
+    }
+    const execError = error as ExecError;
+    const text = `${execError.message} ${execError.stderr ?? ""}`.toLowerCase();
+    return execError.code === "ENOENT" || text.includes("enoent");
+  }
+
+  private resolveCollisionSafeSessionName(
+    baseName: string,
+    existingSessionNames: Set<string>,
+  ): string {
+    if (!existingSessionNames.has(baseName)) {
+      return baseName;
+    }
+    let suffix = 2;
+    let candidate = `${baseName}-${suffix}`;
+    while (existingSessionNames.has(candidate)) {
+      suffix += 1;
+      candidate = `${baseName}-${suffix}`;
+    }
+    return candidate;
+  }
+
+  private shellQuote(value: string): string {
+    return `'${value.replace(/'/g, "'\\''")}'`;
+  }
+}

--- a/src/services/ZellijSessionManager.ts
+++ b/src/services/ZellijSessionManager.ts
@@ -138,7 +138,6 @@ export class ZellijSessionManager {
     return `zellij attach ${this.shellQuote(sessionName)}`;
   }
 
-  /** Kill a zellij session by name */
   public async killSession(sessionName: string): Promise<void> {
     try {
       await this.runZellij(["kill-session", sessionName]);
@@ -147,7 +146,6 @@ export class ZellijSessionManager {
     }
   }
 
-  /** Switch to a different zellij session */
   public async switchSession(sessionName: string): Promise<void> {
     try {
       await this.runZellij(["action", "switch-session", sessionName]);
@@ -156,7 +154,6 @@ export class ZellijSessionManager {
     }
   }
 
-  /** Split the current pane in given direction. Returns new pane ID. */
   public async splitPane(
     direction: "h" | "v",
     options?: { command?: string; workingDirectory?: string },
@@ -183,7 +180,6 @@ export class ZellijSessionManager {
     }
   }
 
-  /** Close the focused pane */
   public async killPane(): Promise<void> {
     try {
       await this.runZellij(["action", "close-pane"]);
@@ -192,7 +188,6 @@ export class ZellijSessionManager {
     }
   }
 
-  /** Focus a specific pane by ID */
   public async selectPane(paneId: string): Promise<void> {
     try {
       await this.runZellij(["action", "focus-pane-id", paneId]);
@@ -201,7 +196,6 @@ export class ZellijSessionManager {
     }
   }
 
-  /** Resize the focused pane */
   public async resizePane(
     direction: "left" | "right" | "up" | "down",
     adjustment: number,
@@ -218,7 +212,6 @@ export class ZellijSessionManager {
     }
   }
 
-  /** Toggle fullscreen on focused pane */
   public async zoomPane(): Promise<void> {
     try {
       await this.runZellij(["action", "toggle-fullscreen"]);
@@ -227,7 +220,6 @@ export class ZellijSessionManager {
     }
   }
 
-  /** Send text to the focused pane */
   public async sendTextToPane(
     text: string,
     options?: { submit?: boolean },
@@ -242,7 +234,6 @@ export class ZellijSessionManager {
     }
   }
 
-  /** List all panes in current session */
   public async listPanes(): Promise<ZellijPane[]> {
     try {
       const stdout = await this.runZellij(["action", "list-panes"]);
@@ -255,7 +246,6 @@ export class ZellijSessionManager {
     }
   }
 
-  /** Create a new tab */
   public async createTab(options?: {
     name?: string;
     workingDirectory?: string;
@@ -275,7 +265,6 @@ export class ZellijSessionManager {
     }
   }
 
-  /** Go to next tab */
   public async nextTab(): Promise<void> {
     try {
       await this.runZellij(["action", "go-to-next-tab"]);
@@ -284,7 +273,6 @@ export class ZellijSessionManager {
     }
   }
 
-  /** Go to previous tab */
   public async prevTab(): Promise<void> {
     try {
       await this.runZellij(["action", "go-to-previous-tab"]);
@@ -293,7 +281,6 @@ export class ZellijSessionManager {
     }
   }
 
-  /** Close current tab */
   public async killTab(): Promise<void> {
     try {
       await this.runZellij(["action", "close-tab"]);
@@ -302,7 +289,6 @@ export class ZellijSessionManager {
     }
   }
 
-  /** Switch to tab by 1-based index */
   public async selectTab(index: number): Promise<void> {
     try {
       await this.runZellij(["action", "go-to-tab", String(index)]);
@@ -311,7 +297,6 @@ export class ZellijSessionManager {
     }
   }
 
-  /** Rename current tab */
   public async renameTab(name: string): Promise<void> {
     try {
       await this.runZellij(["action", "rename-tab", name]);
@@ -320,7 +305,6 @@ export class ZellijSessionManager {
     }
   }
 
-  /** List all tabs */
   public async listTabs(): Promise<ZellijTab[]> {
     try {
       const stdout = await this.runZellij(["action", "list-tabs"]);
@@ -333,7 +317,6 @@ export class ZellijSessionManager {
     }
   }
 
-  /** Get active focus info */
   public async getActiveFocus(): Promise<
     { tabName: string; paneId: string } | undefined
   > {
@@ -355,7 +338,6 @@ export class ZellijSessionManager {
       return undefined;
     }
   }
-  /** Dump screen content of focused pane */
   public async dumpScreen(): Promise<string> {
     try {
       return await this.runZellij(["action", "dump-screen"]);
@@ -443,7 +425,12 @@ export class ZellijSessionManager {
       return undefined;
     }
     const tabParts = line.split("\t");
-    const title = tabParts.length >= 2 ? tabParts[1]?.trim() ?? "" : this.extractNamedValue(line, ["title", "name"]) ?? "";
+    let title = "";
+    if (tabParts.length >= 2) {
+      title = tabParts[1]?.trim() ?? "";
+    } else {
+      title = this.extractNamedValue(line, ["title", "name"]) ?? "";
+    }
     return {
       id,
       title,
@@ -466,18 +453,16 @@ export class ZellijSessionManager {
   }
 
   private parseTabFromLine(line: string, fallbackIndex: number): ZellijTab {
-    // zellij action list-tabs output is whitespace-separated:
-    // "TAB_ID  POSITION  NAME" (header) then "0  0  Tab #1"
     const parts = line.split(/\s{2,}|\t+/).map((p) => p.trim()).filter(Boolean);
     if (parts.length >= 3) {
       const numericId = Number(parts[0]);
       const numericPos = Number(parts[1]);
-      const positionIndex =
-        Number.isFinite(numericPos) && numericPos >= 0
-          ? numericPos + 1
-          : Number.isFinite(numericId) && numericId >= 0
-            ? numericId + 1
-            : fallbackIndex;
+      let positionIndex = fallbackIndex;
+      if (Number.isFinite(numericPos) && numericPos >= 0) {
+        positionIndex = numericPos + 1;
+      } else if (Number.isFinite(numericId) && numericId >= 0) {
+        positionIndex = numericId + 1;
+      }
       return {
         index: positionIndex,
         name: parts[2] ?? `Tab ${positionIndex}`,
@@ -584,7 +569,7 @@ export class ZellijSessionManager {
   }
 
   private async runZellij(args: string[], cwd?: string): Promise<string> {
-    return await new Promise<string>((resolve, reject) => {
+    return new Promise<string>((resolve, reject) => {
       this.runExecFile("zellij", args, cwd ? { cwd } : {}, (error, stdout, stderr) => {
         if (error) {
           reject(Object.assign(error, { stderr: stderr || (error as ExecError).stderr || "" }));

--- a/src/services/ZellijSessionManager.ts
+++ b/src/services/ZellijSessionManager.ts
@@ -37,6 +37,19 @@ interface EnsureZellijSessionResult {
   session: TmuxSession;
 }
 
+export interface ZellijPane {
+  id: string;
+  title: string;
+  isFocused: boolean;
+  isFloating: boolean;
+}
+
+export interface ZellijTab {
+  index: number;
+  name: string;
+  isActive: boolean;
+}
+
 export class ZellijSessionManager {
   public constructor(
     _logger?: ILogger,
@@ -125,6 +138,236 @@ export class ZellijSessionManager {
     return `zellij attach ${this.shellQuote(sessionName)}`;
   }
 
+  /** Kill a zellij session by name */
+  public async killSession(sessionName: string): Promise<void> {
+    try {
+      await this.runZellij(["kill-session", sessionName]);
+    } catch (error) {
+      this.throwUnavailableOrOriginal(error);
+    }
+  }
+
+  /** Switch to a different zellij session */
+  public async switchSession(sessionName: string): Promise<void> {
+    try {
+      await this.runZellij(["action", "switch-session", sessionName]);
+    } catch (error) {
+      this.throwUnavailableOrOriginal(error);
+    }
+  }
+
+  /** Split the current pane in given direction. Returns new pane ID. */
+  public async splitPane(
+    direction: "h" | "v",
+    options?: { command?: string; workingDirectory?: string },
+  ): Promise<string> {
+    const zellijDirection = direction === "h" ? "right" : "down";
+    const args = ["action", "new-pane", "--direction", zellijDirection];
+
+    if (options?.workingDirectory) {
+      args.push("--cwd", options.workingDirectory);
+    }
+    if (options?.command) {
+      args.push("--command", options.command);
+    }
+
+    try {
+      const stdout = await this.runZellij(args, options?.workingDirectory);
+      const paneId = this.extractPaneId(stdout);
+      if (!paneId) {
+        throw new Error("Failed to get pane ID from new-pane output");
+      }
+      return paneId;
+    } catch (error) {
+      this.throwUnavailableOrOriginal(error);
+    }
+  }
+
+  /** Close the focused pane */
+  public async killPane(): Promise<void> {
+    try {
+      await this.runZellij(["action", "close-pane"]);
+    } catch (error) {
+      this.throwUnavailableOrOriginal(error);
+    }
+  }
+
+  /** Focus a specific pane by ID */
+  public async selectPane(paneId: string): Promise<void> {
+    try {
+      await this.runZellij(["action", "focus-pane-id", paneId]);
+    } catch (error) {
+      this.throwUnavailableOrOriginal(error);
+    }
+  }
+
+  /** Resize the focused pane */
+  public async resizePane(
+    direction: "left" | "right" | "up" | "down",
+    adjustment: number,
+  ): Promise<void> {
+    try {
+      await this.runZellij([
+        "action",
+        "resize",
+        `--${direction}`,
+        this.formatSignedAdjustment(adjustment),
+      ]);
+    } catch (error) {
+      this.throwUnavailableOrOriginal(error);
+    }
+  }
+
+  /** Toggle fullscreen on focused pane */
+  public async zoomPane(): Promise<void> {
+    try {
+      await this.runZellij(["action", "toggle-fullscreen"]);
+    } catch (error) {
+      this.throwUnavailableOrOriginal(error);
+    }
+  }
+
+  /** Send text to the focused pane */
+  public async sendTextToPane(
+    text: string,
+    options?: { submit?: boolean },
+  ): Promise<void> {
+    try {
+      await this.runZellij(["action", "write-chars", text]);
+      if (options?.submit) {
+        await this.runZellij(["action", "send-keys", "Enter"]);
+      }
+    } catch (error) {
+      this.throwUnavailableOrOriginal(error);
+    }
+  }
+
+  /** List all panes in current session */
+  public async listPanes(): Promise<ZellijPane[]> {
+    try {
+      const stdout = await this.runZellij(["action", "list-panes"]);
+      return this.parsePanes(stdout);
+    } catch (error) {
+      if (this.isNoSessionsError(error)) {
+        return [];
+      }
+      this.throwUnavailableOrOriginal(error);
+    }
+  }
+
+  /** Create a new tab */
+  public async createTab(options?: {
+    name?: string;
+    workingDirectory?: string;
+  }): Promise<void> {
+    const args = ["action", "new-tab"];
+    if (options?.name) {
+      args.push("--name", options.name);
+    }
+    if (options?.workingDirectory) {
+      args.push("--cwd", options.workingDirectory);
+    }
+
+    try {
+      await this.runZellij(args, options?.workingDirectory);
+    } catch (error) {
+      this.throwUnavailableOrOriginal(error);
+    }
+  }
+
+  /** Go to next tab */
+  public async nextTab(): Promise<void> {
+    try {
+      await this.runZellij(["action", "go-to-next-tab"]);
+    } catch (error) {
+      this.throwUnavailableOrOriginal(error);
+    }
+  }
+
+  /** Go to previous tab */
+  public async prevTab(): Promise<void> {
+    try {
+      await this.runZellij(["action", "go-to-previous-tab"]);
+    } catch (error) {
+      this.throwUnavailableOrOriginal(error);
+    }
+  }
+
+  /** Close current tab */
+  public async killTab(): Promise<void> {
+    try {
+      await this.runZellij(["action", "close-tab"]);
+    } catch (error) {
+      this.throwUnavailableOrOriginal(error);
+    }
+  }
+
+  /** Switch to tab by 1-based index */
+  public async selectTab(index: number): Promise<void> {
+    try {
+      await this.runZellij(["action", "go-to-tab", String(index)]);
+    } catch (error) {
+      this.throwUnavailableOrOriginal(error);
+    }
+  }
+
+  /** Rename current tab */
+  public async renameTab(name: string): Promise<void> {
+    try {
+      await this.runZellij(["action", "rename-tab", name]);
+    } catch (error) {
+      this.throwUnavailableOrOriginal(error);
+    }
+  }
+
+  /** List all tabs */
+  public async listTabs(): Promise<ZellijTab[]> {
+    try {
+      const stdout = await this.runZellij(["action", "list-tabs"]);
+      return this.parseTabs(stdout);
+    } catch (error) {
+      if (this.isNoSessionsError(error)) {
+        return [];
+      }
+      this.throwUnavailableOrOriginal(error);
+    }
+  }
+
+  /** Get active focus info */
+  public async getActiveFocus(): Promise<
+    { tabName: string; paneId: string } | undefined
+  > {
+    try {
+      const [tabInfo, panes] = await Promise.all([
+        this.runZellij(["action", "current-tab-info"]),
+        this.listPanes(),
+      ]);
+      const tabName = this.extractTabName(tabInfo);
+      const focusedPane = panes.find((pane) => pane.isFocused);
+      if (!tabName || !focusedPane) {
+        return undefined;
+      }
+      return { tabName, paneId: focusedPane.id };
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** Dump screen content of focused pane */
+  public async dumpScreen(): Promise<string> {
+    try {
+      return await this.runZellij(["action", "dump-screen", "/dev/stdout"]);
+    } catch (error) {
+      if (this.isZellijUnavailable(error)) {
+        throw new ZellijUnavailableError();
+      }
+      if (this.isNoSessionsError(error)) {
+        return "";
+      }
+      throw error;
+    }
+  }
+
   private parseSessions(stdout: string): TmuxSession[] {
     return stdout
       .split(/\r?\n/)
@@ -141,11 +384,196 @@ export class ZellijSessionManager {
       });
   }
 
+  private parsePanes(stdout: string): ZellijPane[] {
+    const json = this.tryParseJson(stdout);
+    if (Array.isArray(json)) {
+      return json
+        .map((entry) => this.parsePaneFromUnknown(entry))
+        .filter((pane): pane is ZellijPane => pane !== undefined);
+    }
+
+    return stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => this.parsePaneFromLine(line))
+      .filter((pane): pane is ZellijPane => pane !== undefined);
+  }
+
+  private parseTabs(stdout: string): ZellijTab[] {
+    const json = this.tryParseJson(stdout);
+    if (Array.isArray(json)) {
+      return json
+        .map((entry, index) => this.parseTabFromUnknown(entry, index + 1))
+        .filter((tab): tab is ZellijTab => tab !== undefined);
+    }
+
+    return stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line, index) => this.parseTabFromLine(line, index + 1))
+      .filter(Boolean);
+  }
+
+  private parsePaneFromUnknown(value: unknown): ZellijPane | undefined {
+    if (!this.isRecord(value)) {
+      return undefined;
+    }
+
+    const id = this.extractPaneIdFromValue(value.id) ?? this.extractPaneId(JSON.stringify(value));
+    if (!id) {
+      return undefined;
+    }
+
+    return {
+      id,
+      title: this.stringFromRecord(value, ["title", "name", "pane_title"]) ?? "",
+      isFocused: this.booleanFromRecord(value, ["is_focused", "isFocused", "focused"]),
+      isFloating: this.booleanFromRecord(value, ["is_floating", "isFloating", "floating"]),
+    };
+  }
+
+  private parsePaneFromLine(line: string): ZellijPane | undefined {
+    const id = this.extractPaneId(line);
+    if (!id) {
+      return undefined;
+    }
+    const tabParts = line.split("\t");
+    const title = tabParts.length >= 2 ? tabParts[1]?.trim() ?? "" : this.extractNamedValue(line, ["title", "name"]) ?? "";
+    return {
+      id,
+      title,
+      isFocused: /\b(is_)?focused\b\s*[:=]\s*true\b|\b(active|current)\b/i.test(line),
+      isFloating: /\b(is_)?floating\b\s*[:=]\s*true\b/i.test(line),
+    };
+  }
+
+  private parseTabFromUnknown(value: unknown, fallbackIndex: number): ZellijTab | undefined {
+    if (!this.isRecord(value)) {
+      return undefined;
+    }
+    const indexValue = value.index ?? value.position ?? value.tab_index;
+    const name = this.stringFromRecord(value, ["name", "title", "tab_name"]);
+    return {
+      index: typeof indexValue === "number" ? indexValue : fallbackIndex,
+      name: name ?? `Tab ${fallbackIndex}`,
+      isActive: this.booleanFromRecord(value, ["is_active", "isActive", "active", "focused"]),
+    };
+  }
+
+  private parseTabFromLine(line: string, fallbackIndex: number): ZellijTab {
+    const tabParts = line.split("\t");
+    if (tabParts.length >= 3) {
+      return {
+        index: Number(tabParts[0]) || fallbackIndex,
+        name: tabParts[1]?.trim() ?? `Tab ${fallbackIndex}`,
+        isActive: this.parseBooleanToken(tabParts[2]),
+      };
+    }
+
+    const numbered = line.match(/^\s*(\d+)\s*[:.)-]?\s*(.*?)\s*$/);
+    const index = numbered?.[1] ? Number(numbered[1]) : fallbackIndex;
+    const rawName = numbered?.[2] ?? line;
+    const name = rawName
+      .replace(/\b(active|current|focused)\b/gi, "")
+      .replace(/[()[\]{}*:]/g, "")
+      .trim();
+    return {
+      index,
+      name: name || `Tab ${index}`,
+      isActive: /\bactive\b|\bcurrent\b|\bfocused\b|\*/i.test(line),
+    };
+  }
+
+  private extractTabName(stdout: string): string | undefined {
+    const json = this.tryParseJson(stdout);
+    if (this.isRecord(json)) {
+      return this.stringFromRecord(json, ["name", "title", "tab_name"]);
+    }
+    return this.extractNamedValue(stdout, ["name", "title", "tab_name"]) ?? stdout.trim().split(/\r?\n/)[0]?.trim();
+  }
+
+  private extractPaneId(stdout: string): string | undefined {
+    return stdout.match(/\b(?:terminal|plugin)_\d+\b/)?.[0];
+  }
+
+  private extractPaneIdFromValue(value: unknown): string | undefined {
+    if (typeof value === "string") {
+      return this.extractPaneId(value);
+    }
+    if (typeof value === "number") {
+      return `terminal_${value}`;
+    }
+    return undefined;
+  }
+
+  private extractNamedValue(text: string, names: string[]): string | undefined {
+    for (const name of names) {
+      const match = text.match(new RegExp(`${name}[\\s:=]+["']?([^,"'\\]}\\)]+)`, "i"));
+      const value = match?.[1]?.trim();
+      if (value) {
+        return value;
+      }
+    }
+    return undefined;
+  }
+
+  private tryParseJson(stdout: string): unknown {
+    const trimmed = stdout.trim();
+    if (!trimmed.startsWith("[") && !trimmed.startsWith("{")) {
+      return undefined;
+    }
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return undefined;
+    }
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+  }
+
+  private stringFromRecord(
+    record: Record<string, unknown>,
+    keys: string[],
+  ): string | undefined {
+    for (const key of keys) {
+      const value = record[key];
+      if (typeof value === "string") {
+        return value;
+      }
+    }
+    return undefined;
+  }
+
+  private booleanFromRecord(record: Record<string, unknown>, keys: string[]): boolean {
+    for (const key of keys) {
+      const value = record[key];
+      if (typeof value === "boolean") {
+        return value;
+      }
+      if (typeof value === "string") {
+        return this.parseBooleanToken(value);
+      }
+    }
+    return false;
+  }
+
+  private parseBooleanToken(value: string | undefined): boolean {
+    return /^(1|true|yes|active|current|focused)$/i.test(value?.trim() ?? "");
+  }
+
+  private formatSignedAdjustment(adjustment: number): string {
+    return adjustment >= 0 ? `+${adjustment}` : String(adjustment);
+  }
+
   private async runZellij(args: string[], cwd?: string): Promise<string> {
     return await new Promise<string>((resolve, reject) => {
       this.runExecFile("zellij", args, cwd ? { cwd } : {}, (error, stdout, stderr) => {
         if (error) {
-          reject(Object.assign(error, { stderr }));
+          reject(Object.assign(error, { stderr: stderr || (error as ExecError).stderr || "" }));
           return;
         }
         resolve(stdout);
@@ -158,7 +586,10 @@ export class ZellijSessionManager {
       return false;
     }
     const stderr = (error as ExecError).stderr ?? "";
-    return /no sessions|not found/i.test(stderr) || /no sessions/i.test(error.message);
+    return (
+      /no (active )?sessions?|not found/i.test(stderr) ||
+      /no (active )?sessions?/i.test(error.message)
+    );
   }
 
   private isZellijUnavailable(error: unknown): boolean {
@@ -168,6 +599,13 @@ export class ZellijSessionManager {
     const execError = error as ExecError;
     const text = `${execError.message} ${execError.stderr ?? ""}`.toLowerCase();
     return execError.code === "ENOENT" || text.includes("enoent");
+  }
+
+  private throwUnavailableOrOriginal(error: unknown): never {
+    if (this.isZellijUnavailable(error)) {
+      throw new ZellijUnavailableError();
+    }
+    throw error;
   }
 
   private resolveCollisionSafeSessionName(

--- a/src/services/ZellijSessionManager.ts
+++ b/src/services/ZellijSessionManager.ts
@@ -412,6 +412,7 @@ export class ZellijSessionManager {
       .split(/\r?\n/)
       .map((line) => line.trim())
       .filter(Boolean)
+      .filter((line) => !/^(TAB_ID|PANE_ID)\b/i.test(line))
       .map((line, index) => this.parseTabFromLine(line, index + 1))
       .filter(Boolean);
   }
@@ -463,21 +464,30 @@ export class ZellijSessionManager {
   }
 
   private parseTabFromLine(line: string, fallbackIndex: number): ZellijTab {
-    const tabParts = line.split("\t");
-    if (tabParts.length >= 3) {
+    // zellij action list-tabs output is whitespace-separated:
+    // "TAB_ID  POSITION  NAME" (header) then "0  0  Tab #1"
+    const parts = line.split(/\s{2,}|\t+/).map((p) => p.trim()).filter(Boolean);
+    if (parts.length >= 3) {
+      const numericId = Number(parts[0]);
+      const numericPos = Number(parts[1]);
+      const positionIndex =
+        Number.isFinite(numericPos) && numericPos >= 0
+          ? numericPos + 1
+          : Number.isFinite(numericId) && numericId >= 0
+            ? numericId + 1
+            : fallbackIndex;
       return {
-        index: Number(tabParts[0]) || fallbackIndex,
-        name: tabParts[1]?.trim() ?? `Tab ${fallbackIndex}`,
-        isActive: this.parseBooleanToken(tabParts[2]),
+        index: positionIndex,
+        name: parts[2] ?? `Tab ${positionIndex}`,
+        isActive: this.parseBooleanToken(parts[3]),
       };
     }
-
-    const numbered = line.match(/^\s*(\d+)\s*[:.)-]?\s*(.*?)\s*$/);
+    const numbered = line.match(/^\s*(\d+)\s*[:.)\-]?\s*(.*?)\s*$/);
     const index = numbered?.[1] ? Number(numbered[1]) : fallbackIndex;
     const rawName = numbered?.[2] ?? line;
     const name = rawName
       .replace(/\b(active|current|focused)\b/gi, "")
-      .replace(/[()[\]{}*:]/g, "")
+      .replace(/[()\[\]{}*:]/g, "")
       .trim();
     return {
       index,

--- a/src/services/terminalBackends.test.ts
+++ b/src/services/terminalBackends.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { StaticTerminalBackend, TerminalBackendRegistry } from "./terminalBackends";
+
+describe("TerminalBackendRegistry", () => {
+  it("resolves unavailable backends to native", () => {
+    const registry = new TerminalBackendRegistry([
+      new StaticTerminalBackend("native", "Native", true),
+      new StaticTerminalBackend("tmux", "Tmux", false),
+      new StaticTerminalBackend("zellij", "Zellij", false),
+    ]);
+
+    expect(registry.resolveAvailable("tmux")).toBe("native");
+    expect(registry.getAvailability()).toEqual({
+      native: true,
+      tmux: false,
+      zellij: false,
+    });
+  });
+
+  it("cycles native to the next available backend", () => {
+    const registry = new TerminalBackendRegistry([
+      new StaticTerminalBackend("native", "Native", true),
+      new StaticTerminalBackend("tmux", "Tmux", false),
+      new StaticTerminalBackend("zellij", "Zellij", true),
+    ]);
+
+    expect(registry.nextAvailable("native")).toBe("zellij");
+    expect(registry.nextAvailable("zellij")).toBe("native");
+  });
+});

--- a/src/services/terminalBackends.ts
+++ b/src/services/terminalBackends.ts
@@ -1,0 +1,64 @@
+import { TerminalBackendType, TerminalBackendAvailability } from "../types";
+
+export interface TerminalBackend {
+  readonly type: TerminalBackendType;
+  readonly label: string;
+  isAvailable(): boolean;
+}
+
+export class StaticTerminalBackend implements TerminalBackend {
+  public constructor(
+    public readonly type: TerminalBackendType,
+    public readonly label: string,
+    private readonly available: boolean,
+  ) {}
+
+  public isAvailable(): boolean {
+    return this.available;
+  }
+}
+
+export class TerminalBackendRegistry {
+  private readonly order: TerminalBackendType[] = ["native", "tmux", "zellij"];
+  private readonly backends = new Map<TerminalBackendType, TerminalBackend>();
+
+  public constructor(backends: readonly TerminalBackend[]) {
+    for (const backend of backends) {
+      this.backends.set(backend.type, backend);
+    }
+  }
+
+  public getAvailability(): TerminalBackendAvailability {
+    return {
+      native: this.isAvailable("native"),
+      tmux: this.isAvailable("tmux"),
+      zellij: this.isAvailable("zellij"),
+    };
+  }
+
+  public isAvailable(type: TerminalBackendType): boolean {
+    return this.backends.get(type)?.isAvailable() ?? false;
+  }
+
+  public resolveAvailable(
+    requested: TerminalBackendType,
+    fallback: TerminalBackendType = "native",
+  ): TerminalBackendType {
+    if (this.isAvailable(requested)) {
+      return requested;
+    }
+    return this.isAvailable(fallback) ? fallback : "native";
+  }
+
+  public nextAvailable(current: TerminalBackendType): TerminalBackendType {
+    const startIndex = this.order.indexOf(current);
+    const offset = startIndex >= 0 ? startIndex : 0;
+    for (let step = 1; step <= this.order.length; step += 1) {
+      const candidate = this.order[(offset + step) % this.order.length];
+      if (this.isAvailable(candidate)) {
+        return candidate;
+      }
+    }
+    return "native";
+  }
+}

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import type {
   HostMessage,
+  TerminalBackendType,
   TmuxDashboardActionMessage,
   TmuxDashboardHostMessage,
   WebviewMessage,
@@ -132,6 +133,18 @@ describe("Types", () => {
       expect(killMessage.type).toBe("killSession");
       expect(killMessage.sessionId).toBe("workspace-a");
       expect(createMessage.type).toBe("createTmuxSession");
+    });
+
+    it("should accept terminal backend selection messages", () => {
+      const backend: TerminalBackendType = "zellij";
+      const selectMessage: WebviewMessage = {
+        type: "selectTerminalBackend",
+        backend,
+      };
+      const cycleMessage: WebviewMessage = { type: "cycleTerminalBackend" };
+
+      expect(selectMessage.backend).toBe("zellij");
+      expect(cycleMessage.type).toBe("cycleTerminalBackend");
     });
 
     it("should accept executeTmuxCommand messages for supported toolbar commands", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,14 @@ export interface DroppedBlobFile {
   data: string;
 }
 
+export type TerminalBackendType = "native" | "tmux" | "zellij";
+
+export interface TerminalBackendAvailability {
+  native: boolean;
+  tmux: boolean;
+  zellij: boolean;
+}
+
 export type WebviewMessage =
   | { type: "terminalInput"; data: string }
   | { type: "terminalResize"; cols: number; rows: number }
@@ -80,7 +88,9 @@ export type WebviewMessage =
   | { type: "zoomTmuxPane" }
   | { type: "toggleDashboard" }
   | { type: "toggleEditorAttachment" }
-  | { type: "sendTmuxPromptChoice"; choice: "tmux" | "shell" }
+  | { type: "sendTmuxPromptChoice"; choice: "tmux" | "shell" | "zellij" }
+  | { type: "selectTerminalBackend"; backend: TerminalBackendType }
+  | { type: "cycleTerminalBackend" }
   | { type: "requestAiToolSelector" }
   | { type: "executeTmuxCommand"; commandId: TmuxWebviewCommandId }
   | {
@@ -359,7 +369,14 @@ export type HostMessage =
   | { type: "clearTerminal" }
   | { type: "focusTerminal" }
   | { type: "webviewVisible" }
-  | { type: "platformInfo"; platform: string; tmuxAvailable?: boolean }
+  | {
+      type: "platformInfo";
+      platform: string;
+      tmuxAvailable?: boolean;
+      zellijAvailable?: boolean;
+      backendAvailability?: TerminalBackendAvailability;
+      activeBackend?: TerminalBackendType;
+    }
   | {
       type: "terminalConfig";
       fontSize: number;
@@ -375,8 +392,9 @@ export type HostMessage =
       windowIndex?: number;
       windowName?: string;
       canKillPane?: boolean;
+      backend?: TerminalBackendType;
     }
-  | { type: "activeSession" }
+  | { type: "activeSession"; backend?: TerminalBackendType }
   | {
       type: "showAiToolSelector";
       sessionId: string;
@@ -397,6 +415,8 @@ export type HostMessage =
       type: "showTmuxPrompt";
       workspaceName: string;
       tmuxAvailable?: boolean;
+      zellijAvailable?: boolean;
+      activeBackend?: TerminalBackendType;
     };
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
@@ -423,4 +443,5 @@ export interface ExtensionConfig {
   enableAutoSpawn: boolean;
   codeActionSeverities: DiagnosticSeverity[];
   collapseSecondaryBarOnEditorOpen: boolean;
+  terminalBackend: TerminalBackendType;
 }

--- a/src/webview/dashboard-manager.tsx
+++ b/src/webview/dashboard-manager.tsx
@@ -236,7 +236,6 @@ document.addEventListener("click", (event) => {
 
     return;
   }
-  // Tmux command dropdown trigger
   if (target.closest("#tmux-command-trigger")) {
     if (TmuxCmd.isVisible()) {
       TmuxCmd.hide();
@@ -253,7 +252,6 @@ document.addEventListener("click", (event) => {
     return;
   }
 
-  // Tmux command dropdown item click
   if (
     target.closest(".tmux-cmd-item") &&
     !target.closest(".tmux-cmd-item.disabled")
@@ -262,7 +260,6 @@ document.addEventListener("click", (event) => {
     return;
   }
 
-  // Tmux command dropdown click-outside close
   if (
     TmuxCmd.isVisible() &&
     !target.closest("#tmux-command-dropdown") &&

--- a/src/webview/dashboard-manager.tsx
+++ b/src/webview/dashboard-manager.tsx
@@ -245,7 +245,10 @@ document.addEventListener("click", (event) => {
         ? lastPayload.sessions
         : [];
       const activeSession = sessions.find((s) => s.isActive);
-      TmuxCmd.show(activeSession?.id ?? null);
+      const activeBackend = activeSession?.name.startsWith("Zellij: ")
+        ? "zellij"
+        : "tmux";
+      TmuxCmd.show(activeSession?.id ?? null, activeBackend);
     }
     return;
   }

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -3,6 +3,7 @@ import * as TmuxPrompt from "./tmux-prompt";
 import * as AiSelector from "./ai-tool-selector";
 import * as TmuxCmd from "./tmux-command-dropdown";
 import { HostMessage } from "../types";
+import type { TerminalBackendAvailability, TerminalBackendType } from "../types";
 import {
   copySelectionToClipboard,
   handlePasteEventWithImageSupport,
@@ -19,7 +20,12 @@ import {
 } from "./toolbar";
 
 let currentSessionId: string | null = null;
-let isTmuxAvailable = true;
+let activeBackend: TerminalBackendType = "native";
+let backendAvailability: TerminalBackendAvailability = {
+  native: true,
+  tmux: true,
+  zellij: false,
+};
 
 function toggleTmuxCommandMenu(): void {
   if (!currentSessionId) {
@@ -33,11 +39,17 @@ function toggleTmuxCommandMenu(): void {
   }
 }
 
-function updateTmuxOnlyElements(available: boolean): void {
+function updateBackendOnlyElements(): void {
   const elements = document.querySelectorAll("[data-tmux-only]");
   Array.from(elements).forEach((el) => {
     if (el instanceof HTMLElement) {
-      el.style.display = available ? "" : "none";
+      el.style.display = backendAvailability.tmux ? "" : "none";
+    }
+  });
+  const zellijElements = document.querySelectorAll("[data-zellij-only]");
+  Array.from(zellijElements).forEach((el) => {
+    if (el instanceof HTMLElement) {
+      el.style.display = backendAvailability.zellij ? "" : "none";
     }
   });
 }
@@ -52,25 +64,32 @@ const callbacks: MessageHandlerCallbacks = {
 
     if ("sessionName" in message && message.sessionName) {
       currentSessionId = message.sessionId;
+      activeBackend = message.backend ?? "tmux";
       if (label) {
         const windowSuffix =
           message.windowIndex !== undefined
             ? ` [${message.windowIndex}]${message.windowName ? ` ${message.windowName}` : ""}`
             : "";
-        label.textContent = message.sessionName + windowSuffix;
+        const backendPrefix = activeBackend === "zellij" ? "Zellij: " : "";
+        label.textContent = backendPrefix + message.sessionName + windowSuffix;
       }
       if (toolbarControls) {
-        toolbarControls.classList.remove("hidden");
+        if (activeBackend === "tmux") {
+          toolbarControls.classList.remove("hidden");
+        } else {
+          toolbarControls.classList.add("hidden");
+        }
       }
     } else {
       currentSessionId = null;
+      activeBackend = "native";
       if (label) label.textContent = "Native Shell";
       if (toolbarControls) {
         toolbarControls.classList.add("hidden");
       }
     }
 
-    updateBackendToggleButtonState(currentSessionId !== null, isTmuxAvailable);
+    updateBackendToggleButtonState(activeBackend, backendAvailability);
   },
 
   onToggleTmuxCommandToolbar() {
@@ -88,18 +107,20 @@ const callbacks: MessageHandlerCallbacks = {
   },
 
   onShowTmuxPrompt(message) {
-    if (message.tmuxAvailable === false) {
-      // tmux not installed — auto-select shell
-      postMessage({ type: "sendTmuxPromptChoice", choice: "shell" });
-    } else {
-      TmuxPrompt.show(message.workspaceName);
-    }
+    backendAvailability.tmux = message.tmuxAvailable !== false;
+    backendAvailability.zellij = message.zellijAvailable === true;
+    TmuxPrompt.show(message.workspaceName, backendAvailability);
   },
 
   onPlatformInfo(message) {
-    isTmuxAvailable = message.tmuxAvailable !== false;
-    updateTmuxOnlyElements(isTmuxAvailable);
-    updateBackendToggleButtonState(currentSessionId !== null, isTmuxAvailable);
+    backendAvailability = message.backendAvailability ?? {
+      native: true,
+      tmux: message.tmuxAvailable !== false,
+      zellij: message.zellijAvailable === true,
+    };
+    activeBackend = message.activeBackend ?? activeBackend;
+    updateBackendOnlyElements();
+    updateBackendToggleButtonState(activeBackend, backendAvailability);
   },
 };
 
@@ -158,7 +179,7 @@ function initApp(): void {
   setupReloadButton();
   setupEditorAttachmentButton();
   setupTmuxCommandButton(() => currentSessionId);
-  setupBackendToggleButton(() => currentSessionId !== null);
+  setupBackendToggleButton(() => activeBackend);
 
   window.addEventListener("message", (event: MessageEvent) => {
     messageHandler.handleEvent(event as MessageEvent<HostMessage>);
@@ -187,7 +208,7 @@ const tmuxPromptCallbacks = {
     if (m && m.type === "sendTmuxPromptChoice") {
       postMessage({
         type: "sendTmuxPromptChoice",
-        choice: String(m.choice) as "tmux" | "shell",
+        choice: String(m.choice) as "tmux" | "shell" | "zellij",
       });
     }
   },

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -35,7 +35,7 @@ function toggleTmuxCommandMenu(): void {
   if (TmuxCmd.isVisible()) {
     TmuxCmd.hide();
   } else {
-    TmuxCmd.show(currentSessionId);
+    TmuxCmd.show(currentSessionId, activeBackend);
   }
 }
 
@@ -74,7 +74,7 @@ const callbacks: MessageHandlerCallbacks = {
         label.textContent = backendPrefix + message.sessionName + windowSuffix;
       }
       if (toolbarControls) {
-        if (activeBackend === "tmux") {
+        if (activeBackend === "tmux" || activeBackend === "zellij") {
           toolbarControls.classList.remove("hidden");
         } else {
           toolbarControls.classList.add("hidden");
@@ -178,7 +178,7 @@ function initApp(): void {
 
   setupReloadButton();
   setupEditorAttachmentButton();
-  setupTmuxCommandButton(() => currentSessionId);
+  setupTmuxCommandButton(() => currentSessionId, () => activeBackend);
   setupBackendToggleButton(() => activeBackend);
 
   window.addEventListener("message", (event: MessageEvent) => {
@@ -227,7 +227,7 @@ function setupAiToolSelectorEvents(): void {
         if (TmuxCmd.isVisible()) {
           TmuxCmd.hide();
         } else {
-          TmuxCmd.show(currentSessionId);
+          TmuxCmd.show(currentSessionId, activeBackend);
         }
       }
       return;

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -14,9 +14,12 @@ import {
   setupEditorAttachmentButton,
   setupReloadButton,
   setupTmuxCommandButton,
+  setupBackendToggleButton,
+  updateBackendToggleButtonState,
 } from "./toolbar";
 
 let currentSessionId: string | null = null;
+let isTmuxAvailable = true;
 
 function toggleTmuxCommandMenu(): void {
   if (!currentSessionId) {
@@ -44,9 +47,11 @@ const callbacks: MessageHandlerCallbacks = {
     const toolbar = document.getElementById("tmux-toolbar");
     const label = document.getElementById("tmux-session-label");
     const toolbarControls = document.querySelector(".toolbar-controls");
+
+    if (toolbar) toolbar.classList.remove("hidden");
+
     if ("sessionName" in message && message.sessionName) {
       currentSessionId = message.sessionId;
-      if (toolbar) toolbar.classList.remove("hidden");
       if (label) {
         const windowSuffix =
           message.windowIndex !== undefined
@@ -59,11 +64,13 @@ const callbacks: MessageHandlerCallbacks = {
       }
     } else {
       currentSessionId = null;
-      if (label) label.textContent = "";
+      if (label) label.textContent = "Native Shell";
       if (toolbarControls) {
         toolbarControls.classList.add("hidden");
       }
     }
+
+    updateBackendToggleButtonState(currentSessionId !== null, isTmuxAvailable);
   },
 
   onToggleTmuxCommandToolbar() {
@@ -90,7 +97,9 @@ const callbacks: MessageHandlerCallbacks = {
   },
 
   onPlatformInfo(message) {
-    updateTmuxOnlyElements(message.tmuxAvailable !== false);
+    isTmuxAvailable = message.tmuxAvailable !== false;
+    updateTmuxOnlyElements(isTmuxAvailable);
+    updateBackendToggleButtonState(currentSessionId !== null, isTmuxAvailable);
   },
 };
 
@@ -149,6 +158,7 @@ function initApp(): void {
   setupReloadButton();
   setupEditorAttachmentButton();
   setupTmuxCommandButton(() => currentSessionId);
+  setupBackendToggleButton(() => currentSessionId !== null);
 
   window.addEventListener("message", (event: MessageEvent) => {
     messageHandler.handleEvent(event as MessageEvent<HostMessage>);

--- a/src/webview/terminal/html.test.ts
+++ b/src/webview/terminal/html.test.ts
@@ -16,6 +16,7 @@ describe("renderTerminalHtml", () => {
     });
 
     expect(html).toContain('id="tmux-toolbar"');
+    expect(html).toContain('id="btn-toggle-backend"');
     expect(html).toContain('id="btn-toggle-editor-attachment"');
     expect(html).toContain('id="terminal-container"');
     expect(html).toContain('id="ai-selector"');

--- a/src/webview/terminal/tmux-prompt-template.html
+++ b/src/webview/terminal/tmux-prompt-template.html
@@ -17,6 +17,20 @@
           </div>
         </div>
       </button>
+      <button
+        type="button"
+        id="tmux-prompt-zellij"
+        class="ai-selector-option"
+        data-zellij-only
+      >
+        <div class="ai-option-icon">Z</div>
+        <div class="ai-option-details">
+          <div class="ai-option-name">Create Zellij Session</div>
+          <div class="ai-option-desc">
+            Start a new zellij session for this workspace
+          </div>
+        </div>
+      </button>
       <button type="button" id="tmux-prompt-shell" class="ai-selector-option">
         <div class="ai-option-icon">⌘</div>
         <div class="ai-option-details">

--- a/src/webview/terminal/tmux-toolbar.html
+++ b/src/webview/terminal/tmux-toolbar.html
@@ -45,6 +45,15 @@
   <div class="toolbar-right">
     <button
       type="button"
+      id="btn-toggle-backend"
+      class="tmux-btn"
+      aria-label="Toggle backend mode"
+      title="Switch to Native Shell"
+    >
+      &#x21C4;
+    </button>
+    <button
+      type="button"
       id="btn-toggle-editor-attachment"
       class="tmux-btn"
       aria-label="Toggle editor mode"

--- a/src/webview/tmux-command-dropdown.test.ts
+++ b/src/webview/tmux-command-dropdown.test.ts
@@ -64,4 +64,21 @@ describe("tmux command dropdown", () => {
       type: "requestAiToolSelector",
     });
   });
+
+  it("uses zellij tab labels and hides unsupported tmux-only commands", () => {
+    document.body.innerHTML = `
+      <div id="tmux-command-dropdown" style="display:none"></div>
+      <input id="tmux-cmd-search-input" />
+      <div id="tmux-command-list"></div>
+    `;
+
+    show("session-1", "zellij");
+
+    const listText = document.getElementById("tmux-command-list")?.textContent ?? "";
+    expect(listText).toContain("New Tab");
+    expect(listText).toContain("Next Tab");
+    expect(listText).not.toContain("New Window");
+    expect(listText).not.toContain("Swap Pane");
+    expect(listText).not.toContain("Rename Window");
+  });
 });

--- a/src/webview/tmux-command-dropdown.ts
+++ b/src/webview/tmux-command-dropdown.ts
@@ -115,6 +115,7 @@ const commands: TmuxCommand[] = [
     label: "Select AI Tool",
     category: "Utility",
     requiresSession: false,
+    unsupportedBackends: ["native"],
     buildMessage: () => ({
       type: "requestAiToolSelector",
     }),

--- a/src/webview/tmux-command-dropdown.ts
+++ b/src/webview/tmux-command-dropdown.ts
@@ -449,7 +449,6 @@ export function show(
     searchInput.value = "";
     searchInput.focus();
 
-    // Add input listener if not already added
     if (!searchInput.dataset.listenerAdded) {
       searchInput.addEventListener("input", (e) => {
         query = (e.target as HTMLInputElement).value;

--- a/src/webview/tmux-command-dropdown.ts
+++ b/src/webview/tmux-command-dropdown.ts
@@ -1,4 +1,5 @@
 import type { WebviewMessage } from "../types";
+import type { TerminalBackendType } from "../types";
 import { postMessage } from "./shared/vscode-api";
 import { escapeHtml } from "./dashboard/utils";
 
@@ -18,6 +19,7 @@ interface TmuxCommand {
   label: string;
   category: string;
   requiresSession: boolean;
+  unsupportedBackends?: TerminalBackendType[];
   buildMessage: (activeSessionId: string | null) => TmuxDropdownMessage;
 }
 
@@ -25,6 +27,7 @@ let visible = false;
 let query = "";
 let focusedIndex = 0;
 let activeSessionId: string | null = null;
+let activeBackend: TerminalBackendType = "tmux";
 
 const commands: TmuxCommand[] = [
   {
@@ -181,6 +184,7 @@ const commands: TmuxCommand[] = [
     label: "Swap Pane",
     category: "Pane",
     requiresSession: true,
+    unsupportedBackends: ["zellij"],
     buildMessage: () => ({
       type: "executeTmuxCommand",
       commandId: "opencodeTui.tmuxSwapPane",
@@ -220,6 +224,7 @@ const commands: TmuxCommand[] = [
     label: "Rename Session",
     category: "Native",
     requiresSession: true,
+    unsupportedBackends: ["zellij"],
     buildMessage: () => ({
       type: "executeTmuxRawCommand",
       subcommand: "rename-session",
@@ -230,6 +235,7 @@ const commands: TmuxCommand[] = [
     label: "Rename Window",
     category: "Native",
     requiresSession: true,
+    unsupportedBackends: ["zellij"],
     buildMessage: () => ({
       type: "executeTmuxRawCommand",
       subcommand: "rename-window",
@@ -240,6 +246,7 @@ const commands: TmuxCommand[] = [
     label: "Last Window",
     category: "Native",
     requiresSession: true,
+    unsupportedBackends: ["zellij"],
     buildMessage: () => ({
       type: "executeTmuxRawCommand",
       subcommand: "last-window",
@@ -250,6 +257,7 @@ const commands: TmuxCommand[] = [
     label: "Last Pane",
     category: "Native",
     requiresSession: true,
+    unsupportedBackends: ["zellij"],
     buildMessage: () => ({
       type: "executeTmuxRawCommand",
       subcommand: "last-pane",
@@ -260,6 +268,7 @@ const commands: TmuxCommand[] = [
     label: "Rotate Window",
     category: "Native",
     requiresSession: true,
+    unsupportedBackends: ["zellij"],
     buildMessage: () => ({
       type: "executeTmuxRawCommand",
       subcommand: "rotate-window",
@@ -270,6 +279,7 @@ const commands: TmuxCommand[] = [
     label: "Select Layout",
     category: "Native",
     requiresSession: true,
+    unsupportedBackends: ["zellij"],
     buildMessage: () => ({
       type: "executeTmuxRawCommand",
       subcommand: "select-layout",
@@ -280,6 +290,7 @@ const commands: TmuxCommand[] = [
     label: "Display Panes",
     category: "Native",
     requiresSession: true,
+    unsupportedBackends: ["zellij"],
     buildMessage: () => ({
       type: "executeTmuxRawCommand",
       subcommand: "display-panes",
@@ -290,6 +301,7 @@ const commands: TmuxCommand[] = [
     label: "Copy Mode",
     category: "Native",
     requiresSession: true,
+    unsupportedBackends: ["zellij"],
     buildMessage: () => ({
       type: "executeTmuxRawCommand",
       subcommand: "copy-mode",
@@ -300,6 +312,7 @@ const commands: TmuxCommand[] = [
     label: "Clear History",
     category: "Native",
     requiresSession: true,
+    unsupportedBackends: ["zellij"],
     buildMessage: () => ({
       type: "executeTmuxRawCommand",
       subcommand: "clear-history",
@@ -310,6 +323,7 @@ const commands: TmuxCommand[] = [
     label: "Detach Client",
     category: "Native",
     requiresSession: true,
+    unsupportedBackends: ["zellij"],
     buildMessage: () => ({
       type: "executeTmuxRawCommand",
       subcommand: "detach-client",
@@ -320,6 +334,7 @@ const commands: TmuxCommand[] = [
     label: "Move Window",
     category: "Native",
     requiresSession: true,
+    unsupportedBackends: ["zellij"],
     buildMessage: () => ({
       type: "executeTmuxRawCommand",
       subcommand: "move-window",
@@ -330,6 +345,7 @@ const commands: TmuxCommand[] = [
     label: "Move Pane",
     category: "Native",
     requiresSession: true,
+    unsupportedBackends: ["zellij"],
     buildMessage: () => ({
       type: "executeTmuxRawCommand",
       subcommand: "move-pane",
@@ -340,6 +356,7 @@ const commands: TmuxCommand[] = [
     label: "Respawn Pane",
     category: "Native",
     requiresSession: true,
+    unsupportedBackends: ["zellij"],
     buildMessage: () => ({
       type: "executeTmuxRawCommand",
       subcommand: "respawn-pane",
@@ -350,6 +367,7 @@ const commands: TmuxCommand[] = [
     label: "Choose Tree",
     category: "Native",
     requiresSession: true,
+    unsupportedBackends: ["zellij"],
     buildMessage: () => ({
       type: "executeTmuxRawCommand",
       subcommand: "choose-tree",
@@ -359,11 +377,27 @@ const commands: TmuxCommand[] = [
 
 function getFilteredCommands(): TmuxCommand[] {
   const q = query.toLowerCase();
-  return commands.filter(
-    (cmd) =>
-      cmd.label.toLowerCase().includes(q) ||
-      cmd.category.toLowerCase().includes(q),
-  );
+  return commands.filter((cmd) => {
+    if (cmd.unsupportedBackends?.includes(activeBackend)) {
+      return false;
+    }
+    return (
+      getCommandLabel(cmd).toLowerCase().includes(q) ||
+      getCommandCategory(cmd).toLowerCase().includes(q)
+    );
+  });
+}
+
+function getCommandLabel(cmd: TmuxCommand): string {
+  return activeBackend === "zellij"
+    ? cmd.label.replace(/Window/g, "Tab")
+    : cmd.label;
+}
+
+function getCommandCategory(cmd: TmuxCommand): string {
+  return activeBackend === "zellij" && cmd.category === "Window"
+    ? "Tab"
+    : cmd.category;
 }
 
 function renderList(): void {
@@ -385,15 +419,19 @@ function renderList(): void {
       const disabledClass = isDisabled ? " disabled" : "";
 
       return `<div class="tmux-cmd-item${focusedClass}${disabledClass}" data-cmd-index="${idx}">
-      <span class="tmux-cmd-category">${escapeHtml(cmd.category)}</span>
-      <span class="tmux-cmd-label">${escapeHtml(cmd.label)}</span>
+      <span class="tmux-cmd-category">${escapeHtml(getCommandCategory(cmd))}</span>
+      <span class="tmux-cmd-label">${escapeHtml(getCommandLabel(cmd))}</span>
     </div>`;
     })
     .join("");
 }
 
-export function show(sessionId: string | null): void {
+export function show(
+  sessionId: string | null,
+  backend: TerminalBackendType = "tmux",
+): void {
   activeSessionId = sessionId;
+  activeBackend = backend;
   visible = true;
   query = "";
   focusedIndex = 0;

--- a/src/webview/tmux-prompt.ts
+++ b/src/webview/tmux-prompt.ts
@@ -9,7 +9,16 @@ export interface TmuxPromptCallbacks {
 
 let visible = false;
 
-export function show(wsName: string): void {
+import type { TerminalBackendAvailability } from "../types";
+
+export function show(
+  wsName: string,
+  availability: TerminalBackendAvailability = {
+    native: true,
+    tmux: true,
+    zellij: false,
+  },
+): void {
   visible = true;
 
   const workspaceEl = document.getElementById("tmux-prompt-workspace");
@@ -22,6 +31,8 @@ export function show(wsName: string): void {
     backdrop.classList.remove("hidden");
     backdrop.style.display = "flex";
   }
+
+  updatePromptBackendOptions(availability);
 }
 
 export function hide(): void {
@@ -53,6 +64,14 @@ export function selectShell(callbacks: TmuxPromptCallbacks): void {
   hide();
 }
 
+export function selectZellij(callbacks: TmuxPromptCallbacks): void {
+  callbacks.postMessage({
+    type: "sendTmuxPromptChoice",
+    choice: "zellij",
+  });
+  hide();
+}
+
 export function handleClick(
   target: Element,
   callbacks: TmuxPromptCallbacks,
@@ -67,9 +86,29 @@ export function handleClick(
     return true;
   }
 
+  if (target.closest("#tmux-prompt-zellij")) {
+    selectZellij(callbacks);
+    return true;
+  }
+
   if (target.id === "tmux-prompt" && !target.closest(".ai-selector-card")) {
     return true;
   }
 
   return false;
+}
+
+function updatePromptBackendOptions(
+  availability: TerminalBackendAvailability,
+): void {
+  const tmuxButton = document.getElementById("tmux-prompt-tmux");
+  if (tmuxButton instanceof HTMLButtonElement) {
+    tmuxButton.disabled = !availability.tmux;
+    tmuxButton.style.display = availability.tmux ? "" : "none";
+  }
+  const zellijButton = document.getElementById("tmux-prompt-zellij");
+  if (zellijButton instanceof HTMLButtonElement) {
+    zellijButton.disabled = !availability.zellij;
+    zellijButton.style.display = availability.zellij ? "" : "none";
+  }
 }

--- a/src/webview/tmux-prompt.ts
+++ b/src/webview/tmux-prompt.ts
@@ -1,8 +1,3 @@
-/**
- * Tmux Session Prompt logic for webviews.
- * Shows a modal when no tmux sessions exist, asking user to create one or use normal shell.
- */
-
 export interface TmuxPromptCallbacks {
   postMessage: (message: unknown) => void;
 }

--- a/src/webview/toolbar/index.test.ts
+++ b/src/webview/toolbar/index.test.ts
@@ -21,41 +21,39 @@ beforeEach(() => {
 });
 
 describe("toolbar backend toggle", () => {
-  it("requests native shell when currently in tmux mode", () => {
-    setupBackendToggleButton(() => true);
+  it("requests backend cycle on click", () => {
+    setupBackendToggleButton(() => "tmux");
 
     document.getElementById("btn-toggle-backend")?.click();
 
     expect(postMessageMock).toHaveBeenCalledWith({
-      type: "sendTmuxPromptChoice",
-      choice: "shell",
+      type: "cycleTerminalBackend",
     });
   });
 
-  it("requests tmux when currently in native mode", () => {
-    setupBackendToggleButton(() => false);
-
-    document.getElementById("btn-toggle-backend")?.click();
-
-    expect(postMessageMock).toHaveBeenCalledWith({
-      type: "sendTmuxPromptChoice",
-      choice: "tmux",
-    });
-  });
-
-  it("disables native-to-tmux switching when tmux is unavailable", () => {
+  it("skips unavailable backends in button title", () => {
     const button = document.getElementById(
       "btn-toggle-backend",
     ) as HTMLButtonElement;
 
-    updateBackendToggleButtonState(false, false);
+    updateBackendToggleButtonState("native", {
+      native: true,
+      tmux: false,
+      zellij: true,
+    });
 
-    expect(button.disabled).toBe(true);
-    expect(button.title).toBe("Tmux is not available");
+    expect(button.disabled).toBe(false);
+    expect(button.title).toBe("Switch to Zellij");
+    expect(button.textContent).toBe("N");
 
-    updateBackendToggleButtonState(true, false);
+    updateBackendToggleButtonState("zellij", {
+      native: true,
+      tmux: false,
+      zellij: true,
+    });
 
     expect(button.disabled).toBe(false);
     expect(button.title).toBe("Switch to Native Shell");
+    expect(button.textContent).toBe("Z");
   });
 });

--- a/src/webview/toolbar/index.test.ts
+++ b/src/webview/toolbar/index.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  setupBackendToggleButton,
+  updateBackendToggleButtonState,
+} from "./index";
+import { resetVsCodeApi } from "../shared/vscode-api";
+
+const postMessageMock = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetVsCodeApi();
+  document.body.innerHTML = `<button id="btn-toggle-backend"></button>`;
+  vi.stubGlobal("acquireVsCodeApi", () => ({
+    postMessage: postMessageMock,
+    getState: vi.fn(),
+    setState: vi.fn(),
+  }));
+});
+
+describe("toolbar backend toggle", () => {
+  it("requests native shell when currently in tmux mode", () => {
+    setupBackendToggleButton(() => true);
+
+    document.getElementById("btn-toggle-backend")?.click();
+
+    expect(postMessageMock).toHaveBeenCalledWith({
+      type: "sendTmuxPromptChoice",
+      choice: "shell",
+    });
+  });
+
+  it("requests tmux when currently in native mode", () => {
+    setupBackendToggleButton(() => false);
+
+    document.getElementById("btn-toggle-backend")?.click();
+
+    expect(postMessageMock).toHaveBeenCalledWith({
+      type: "sendTmuxPromptChoice",
+      choice: "tmux",
+    });
+  });
+
+  it("disables native-to-tmux switching when tmux is unavailable", () => {
+    const button = document.getElementById(
+      "btn-toggle-backend",
+    ) as HTMLButtonElement;
+
+    updateBackendToggleButtonState(false, false);
+
+    expect(button.disabled).toBe(true);
+    expect(button.title).toBe("Tmux is not available");
+
+    updateBackendToggleButtonState(true, false);
+
+    expect(button.disabled).toBe(false);
+    expect(button.title).toBe("Switch to Native Shell");
+  });
+});

--- a/src/webview/toolbar/index.test.ts
+++ b/src/webview/toolbar/index.test.ts
@@ -2,6 +2,7 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  setupTmuxCommandButton,
   setupBackendToggleButton,
   updateBackendToggleButtonState,
 } from "./index";
@@ -55,5 +56,21 @@ describe("toolbar backend toggle", () => {
     expect(button.disabled).toBe(false);
     expect(button.title).toBe("Switch to Native Shell");
     expect(button.textContent).toBe("Z");
+  });
+
+  it("opens command dropdown with the active zellij backend", async () => {
+    document.body.innerHTML = `
+      <button id="btn-tmux-commands"></button>
+      <div id="tmux-command-dropdown" style="display:none"></div>
+      <input id="tmux-cmd-search-input" />
+      <div id="tmux-command-list"></div>
+    `;
+
+    setupTmuxCommandButton(() => "repo-a", () => "zellij");
+    document.getElementById("btn-tmux-commands")?.click();
+
+    const listText = document.getElementById("tmux-command-list")?.textContent ?? "";
+    expect(listText).toContain("New Tab");
+    expect(listText).not.toContain("Swap Pane");
   });
 });

--- a/src/webview/toolbar/index.ts
+++ b/src/webview/toolbar/index.ts
@@ -1,4 +1,5 @@
 import { postMessage } from "../shared/vscode-api";
+import { TerminalBackendAvailability, TerminalBackendType } from "../../types";
 
 import * as TmuxCmd from "../tmux-command-dropdown";
 
@@ -12,39 +13,57 @@ export function setupTmuxCommandButton(
 }
 
 export function setupBackendToggleButton(
-  getIsTmuxMode: () => boolean,
+  _getActiveBackend?: () => TerminalBackendType,
 ): void {
   const btn = document.getElementById("btn-toggle-backend");
   btn?.addEventListener("click", () => {
-    const isTmux = getIsTmuxMode();
-    postMessage({
-      type: "sendTmuxPromptChoice",
-      choice: isTmux ? "shell" : "tmux",
-    });
+    postMessage({ type: "cycleTerminalBackend" });
   });
 }
 
 export function updateBackendToggleButtonState(
-  isTmuxMode: boolean,
-  tmuxAvailable: boolean,
+  activeBackend: TerminalBackendType,
+  availability: TerminalBackendAvailability,
 ): void {
   const btn = document.getElementById(
     "btn-toggle-backend",
   ) as HTMLButtonElement | null;
   if (!btn) return;
 
-  if (isTmuxMode) {
-    btn.title = "Switch to Native Shell";
-    btn.disabled = false;
-  } else {
-    btn.title = "Switch to Tmux";
-    if (!tmuxAvailable) {
-      btn.disabled = true;
-      btn.title = "Tmux is not available";
-    } else {
-      btn.disabled = false;
+  const next = nextAvailableBackend(activeBackend, availability);
+  btn.disabled = next === activeBackend;
+  btn.title = btn.disabled
+    ? "No other terminal backend is available"
+    : `Switch to ${backendLabel(next)}`;
+  btn.textContent = backendGlyph(activeBackend);
+}
+
+function nextAvailableBackend(
+  activeBackend: TerminalBackendType,
+  availability: TerminalBackendAvailability,
+): TerminalBackendType {
+  const order: TerminalBackendType[] = ["native", "tmux", "zellij"];
+  const start = order.indexOf(activeBackend);
+  const offset = start >= 0 ? start : 0;
+  for (let step = 1; step <= order.length; step += 1) {
+    const candidate = order[(offset + step) % order.length];
+    if (availability[candidate]) {
+      return candidate;
     }
   }
+  return activeBackend;
+}
+
+function backendLabel(backend: TerminalBackendType): string {
+  if (backend === "tmux") return "Tmux";
+  if (backend === "zellij") return "Zellij";
+  return "Native Shell";
+}
+
+function backendGlyph(backend: TerminalBackendType): string {
+  if (backend === "tmux") return "T";
+  if (backend === "zellij") return "Z";
+  return "N";
 }
 
 export function setupReloadButton(): void {

--- a/src/webview/toolbar/index.ts
+++ b/src/webview/toolbar/index.ts
@@ -11,6 +11,42 @@ export function setupTmuxCommandButton(
   });
 }
 
+export function setupBackendToggleButton(
+  getIsTmuxMode: () => boolean,
+): void {
+  const btn = document.getElementById("btn-toggle-backend");
+  btn?.addEventListener("click", () => {
+    const isTmux = getIsTmuxMode();
+    postMessage({
+      type: "sendTmuxPromptChoice",
+      choice: isTmux ? "shell" : "tmux",
+    });
+  });
+}
+
+export function updateBackendToggleButtonState(
+  isTmuxMode: boolean,
+  tmuxAvailable: boolean,
+): void {
+  const btn = document.getElementById(
+    "btn-toggle-backend",
+  ) as HTMLButtonElement | null;
+  if (!btn) return;
+
+  if (isTmuxMode) {
+    btn.title = "Switch to Native Shell";
+    btn.disabled = false;
+  } else {
+    btn.title = "Switch to Tmux";
+    if (!tmuxAvailable) {
+      btn.disabled = true;
+      btn.title = "Tmux is not available";
+    } else {
+      btn.disabled = false;
+    }
+  }
+}
+
 export function setupReloadButton(): void {
   document.getElementById("btn-restart")?.addEventListener("click", () => {
     postMessage({ type: "requestRestart" });

--- a/src/webview/toolbar/index.ts
+++ b/src/webview/toolbar/index.ts
@@ -5,10 +5,13 @@ import * as TmuxCmd from "../tmux-command-dropdown";
 
 export function setupTmuxCommandButton(
   getSessionId: () => string | null,
+  getActiveBackend: () => TerminalBackendType = () => "tmux",
 ): void {
   const btnTmuxCommands = document.getElementById("btn-tmux-commands");
   btnTmuxCommands?.addEventListener("click", () => {
-    TmuxCmd.isVisible() ? TmuxCmd.hide() : TmuxCmd.show(getSessionId());
+    TmuxCmd.isVisible()
+      ? TmuxCmd.hide()
+      : TmuxCmd.show(getSessionId(), getActiveBackend());
   });
 }
 


### PR DESCRIPTION
## Summary

Adds multi-backend terminal support, allowing users to select between **tmux**, **zellij**, and **native** terminal backends via VS Code settings dropdown.

### What's New

- **Terminal Backend Selection**: New `opencodeTui.terminalBackend` dropdown (native / tmux / zellij) in VS Code settings
- **ZellijSessionManager**: Full zellij CLI integration with session, pane, and tab management (parity with existing tmux support)
- **Backend-Aware Routing**: SessionRuntime, MessageRouter, and commands route through the active backend
- **Terminal Managers Dashboard**: Zellij sessions appear alongside tmux sessions
- **Webview Toolbar**: Backend-aware toolbar with cycling, AI tool selector, and command dropdown

### Architecture

- **TerminalBackendRegistry**: Registers available backends with availability detection
- **No shared interface**: TmuxSessionManager and ZellijSessionManager keep native APIs; SessionRuntime handles routing
- **Graceful fallback**: If the selected backend is unavailable, falls back to native with a user-visible warning

### Settings Cleanup

Removed redundant/dead settings:
- `enableTmux` / `enableZellij` → replaced by `terminalBackend` dropdown
- `nativeShellDefault` / `tmuxSessionDefault` → dead code (never read in production)
- Fixed `defaultAiTool` description to be backend-agnostic

### Testing

- **749 tests passing** (42 files), compile clean
- Full zellij feature parity verified via smoke tests against zellij 0.44.1
- Tmux behavior unchanged — no regressions

## Test Plan

- [x] `npm test` — 749 passed
- [x] `npm run compile` — clean
- [x] Tmux: session create, switch, pane split, window management
- [x] Zellij: session create, attach, pane split, tab management
- [x] Native: basic terminal, no multiplexer features
- [x] Backend cycling via toolbar button
- [x] Settings dropdown saves/loads correctly
- [x] Unavailable backend falls back to native with warning