### PR TITLE
Fix sidebar startup, tmux launch, and terminal UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Available settings in VS Code settings (`Cmd+,` / `Ctrl+,`):
 | -------------------------------- | ------ | ------- | ------------------------------------------------------------------------ |
 | `opencodeTui.nativeShellDefault` | string | `""`    | Default behavior for native shell switch (`""`, `"opencode"`, `"shell"`) |
 | `opencodeTui.tmuxSessionDefault` | string | `""`    | Default behavior for new tmux sessions (`""`, `"opencode"`, `"shell"`)   |
+| `opencodeTui.showTmuxWindowControls` | boolean | `true` | Show direct tmux session/window controls in the terminal toolbar          |
 
 ### Advanced Settings
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ npx @vscode/vsce package
 ## Usage
 
 1. Click the OpenCode icon in the Activity Bar (sidebar) to open Terminal Managers
-2. The Open Sidebar Terminal terminal is available in the secondary sidebar
+2. The Open Sidebar Terminal is available in the secondary sidebar
 3. Open Sidebar Terminal automatically starts when the terminal view is activated
 4. Interact with OpenCode directly in the sidebar
 
@@ -378,7 +378,7 @@ src/
 
 ## Implementation Details
 
-Based on the excellent [vscode-sidebar-terminal](https://github.com/s-hiraoku/vscode-sidebar-terminal) extension, streamlined specifically for Open Sidebar Terminal:
+Based on the [vscode-sidebar-terminal](https://github.com/s-hiraoku/vscode-sidebar-terminal) extension, streamlined specifically for Open Sidebar Terminal:
 
 - **Terminal Backend**: node-pty for PTY support
 - **Terminal Frontend**: xterm.js with WebGL rendering

--- a/package.json
+++ b/package.json
@@ -401,6 +401,11 @@
           "default": true,
           "description": "Send Ctrl/Cmd + letter shortcuts (including Ctrl+P) directly to the sidebar terminal instead of letting VS Code intercept them. This extension's main purpose is running opencode (a TUI with its own keybindings), so the default is ON. You can turn it off if you prefer normal IDE shortcuts even when the sidebar terminal is focused. Control keys like Ctrl+C are always sent to the terminal."
         },
+        "opencodeTui.showTmuxWindowControls": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show direct tmux session and window controls (+S, previous window, +W, next window) in the terminal toolbar. Turn this off to keep only the tmux command menu."
+        },
         "opencodeTui.autoShareContext": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -573,6 +573,11 @@
           "type": "string",
           "default": "opencode",
           "description": "Name of the default AI tool to launch when creating a new terminal session"
+        },
+        "opencodeTui.promptAiToolOnSession": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show the AI tool selector popup when attaching to or creating a tmux/zellij session"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -380,7 +380,7 @@
         },
         "opencodeTui.autoStartOnOpen": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Automatically start the AI tool when the sidebar is opened. When false, shows a tool selector each time."
         },
         "opencodeTui.shellPath": {
@@ -566,7 +566,7 @@
         },
         "opencodeTui.defaultAiTool": {
           "type": "string",
-          "default": "",
+          "default": "opencode",
           "description": "Name of the default AI tool to launch when creating a new terminal session"
         }
       }

--- a/src/core/commands/terminalCommands.test.ts
+++ b/src/core/commands/terminalCommands.test.ts
@@ -270,7 +270,7 @@ describe("registerTerminalCommands", () => {
     getCommand(noProviderCommands, "opencodeTui.sendAtMention")();
 
     expect(noProviderDeps.outputChannel?.warn).toHaveBeenCalledWith(
-      "[DIAG:sendAtMention] skipped — provider=false editor=true",
+      "[DIAG:sendAtMention] skipped — provider=false",
     );
     expect(noProviderDeps.sendTerminalCwd).toHaveBeenCalledTimes(1);
     expect(noProviderDeps.sendPrompt).not.toHaveBeenCalled();
@@ -285,7 +285,7 @@ describe("registerTerminalCommands", () => {
     getCommand(noEditorCommands, "opencodeTui.sendAtMention")();
 
     expect(noEditorDeps.outputChannel?.warn).toHaveBeenCalledWith(
-      "[DIAG:sendAtMention] skipped — editor=false contextSharingService=true",
+      "[DIAG:sendAtMention] skipped — editor missing",
     );
     expect(noEditorDeps.sendTerminalCwd).toHaveBeenCalledTimes(1);
     expect(noEditorDeps.sendPrompt).not.toHaveBeenCalled();

--- a/src/core/commands/terminalCommands.test.ts
+++ b/src/core/commands/terminalCommands.test.ts
@@ -523,4 +523,18 @@ describe("registerTerminalCommands", () => {
     expect(deps.provider?.openInEditorTab).toHaveBeenCalledTimes(1);
     expect(deps.provider?.toggleEditorAttachment).toHaveBeenCalledTimes(1);
   });
+
+  it("returns the executeCommand promise from opencodeTui.focus", () => {
+    const deps = createDependencies();
+    const commands = registerAndGetCommands(deps);
+    const focusCommand = getCommand(commands, "opencodeTui.focus");
+
+    vi.mocked(vscode.commands.executeCommand).mockResolvedValueOnce(true);
+
+    const result = focusCommand();
+
+    expect(result).toBeDefined();
+    expect(result).toBe(vi.mocked(vscode.commands.executeCommand).mock.results[0]?.value);
+    expect(result).toHaveProperty("then");
+  });
 });

--- a/src/core/commands/terminalCommands.ts
+++ b/src/core/commands/terminalCommands.ts
@@ -43,15 +43,17 @@ export function registerTerminalCommands(
     "opencodeTui.sendToTerminal",
     () => {
       const editor = vscode.window.activeTextEditor;
-      if (editor && !editor.selection.isEmpty) {
-        const selectedText = editor.document.getText(editor.selection);
-        const terminalId = deps.getActiveTerminalId();
-        deps.outputChannel?.info(
-          `[DIAG:sendToTerminal] terminalId="${terminalId}" textLength=${selectedText.length}`,
-        );
-        void deps.sendPrompt(selectedText + "\n");
-        focusSidebarIfConfigured(deps.provider);
+      if (!editor || editor.selection.isEmpty) {
+        return;
       }
+
+      const selectedText = editor.document.getText(editor.selection);
+      const terminalId = deps.getActiveTerminalId();
+      deps.outputChannel?.info(
+        `[DIAG:sendToTerminal] terminalId="${terminalId}" textLength=${selectedText.length}`,
+      );
+      void deps.sendPrompt(selectedText + "\n");
+      focusSidebarIfConfigured(deps.provider);
     },
   );
 
@@ -59,27 +61,27 @@ export function registerTerminalCommands(
     "opencodeTui.sendAtMention",
     () => {
       const editor = vscode.window.activeTextEditor;
-      if (editor) {
-        const fileRef = deps.provider?.formatEditorReference(editor);
-        if (!fileRef) {
-          deps.outputChannel?.warn(
-            `[DIAG:sendAtMention] skipped — provider=${!!deps.provider} editor=${!!editor}`,
-          );
-          deps.sendTerminalCwd();
-          return;
-        }
-        const terminalId = deps.getActiveTerminalId();
-        deps.outputChannel?.info(
-          `[DIAG:sendAtMention] terminalId="${terminalId}" fileRef="${fileRef}"`,
-        );
-        void deps.sendPrompt(fileRef + " ");
-        focusSidebarIfConfigured(deps.provider);
-      } else {
+      if (!editor) {
+        deps.outputChannel?.warn("[DIAG:sendAtMention] skipped — editor missing");
+        deps.sendTerminalCwd();
+        return;
+      }
+
+      const fileRef = deps.provider?.formatEditorReference(editor);
+      if (!fileRef) {
         deps.outputChannel?.warn(
-          `[DIAG:sendAtMention] skipped — editor=${!!editor} contextSharingService=${!!deps.contextSharingService}`,
+          `[DIAG:sendAtMention] skipped — provider=${!!deps.provider}`,
         );
         deps.sendTerminalCwd();
+        return;
       }
+
+      const terminalId = deps.getActiveTerminalId();
+      deps.outputChannel?.info(
+        `[DIAG:sendAtMention] terminalId="${terminalId}" fileRef="${fileRef}"`,
+      );
+      void deps.sendPrompt(fileRef + " ");
+      focusSidebarIfConfigured(deps.provider);
     },
   );
 
@@ -138,7 +140,8 @@ export function registerTerminalCommands(
           return;
         }
 
-        if (!deps.provider) {
+        const provider = deps.provider;
+        if (!provider) {
           fileSendAccumulator = [];
           return;
         }
@@ -150,7 +153,7 @@ export function registerTerminalCommands(
         ];
 
         const fileRefs = uniqueUris.map((u: vscode.Uri) =>
-          deps.provider!.formatUriReference(u),
+          provider.formatUriReference(u),
         );
         const allRefs = fileRefs.join(" ");
 
@@ -183,11 +186,14 @@ export function registerTerminalCommands(
   );
 
   const focusCommand = vscode.commands.registerCommand(
-  "opencodeTui.focus",
-  () => {
-    return vscode.commands.executeCommand("workbench.view.focus", "opencodeTui");
-  },
-);
+    "opencodeTui.focus",
+    () => {
+      return vscode.commands.executeCommand(
+        "workbench.view.focus",
+        "opencodeTui",
+      );
+    },
+  );
 
   const openInEditorCommand = vscode.commands.registerCommand(
     "opencodeTui.openTerminalInEditor",

--- a/src/core/commands/terminalCommands.ts
+++ b/src/core/commands/terminalCommands.ts
@@ -183,11 +183,11 @@ export function registerTerminalCommands(
   );
 
   const focusCommand = vscode.commands.registerCommand(
-    "opencodeTui.focus",
-    () => {
-      vscode.commands.executeCommand("workbench.view.focus", "opencodeTui");
-    },
-  );
+  "opencodeTui.focus",
+  () => {
+    return vscode.commands.executeCommand("workbench.view.focus", "opencodeTui");
+  },
+);
 
   const openInEditorCommand = vscode.commands.registerCommand(
     "opencodeTui.openTerminalInEditor",

--- a/src/core/commands/tmuxSessionCommands.test.ts
+++ b/src/core/commands/tmuxSessionCommands.test.ts
@@ -632,6 +632,11 @@ describe("registerTmuxSessionCommands", () => {
     expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
       "opencodeTui.focus",
     );
+    expect(
+      vi.mocked(vscode.commands.executeCommand).mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      vi.mocked(provider.switchToTmuxSession).mock.invocationCallOrder[0],
+    );
   });
 
   it("ignores switchTmuxSession and killTmuxSession when required inputs are missing", async () => {
@@ -690,6 +695,14 @@ describe("registerTmuxSessionCommands", () => {
     await handlers.killTmuxSession("tmux-2");
 
     expect(provider.createTmuxSession).toHaveBeenCalledTimes(1);
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+      "opencodeTui.focus",
+    );
+    expect(
+      vi.mocked(vscode.commands.executeCommand).mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      vi.mocked(provider.createTmuxSession).mock.invocationCallOrder[0],
+    );
     expect(provider.killTmuxSession).toHaveBeenCalledWith("tmux-2");
   });
 
@@ -917,6 +930,11 @@ describe("registerTmuxSessionCommands", () => {
     expect(provider.switchToTmuxSession).toHaveBeenCalledWith("tmux-b");
     expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
       "opencodeTui.focus",
+    );
+    expect(
+      vi.mocked(vscode.commands.executeCommand).mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      vi.mocked(provider.switchToTmuxSession).mock.invocationCallOrder[0],
     );
   });
 

--- a/src/core/commands/tmuxSessionCommands.ts
+++ b/src/core/commands/tmuxSessionCommands.ts
@@ -168,8 +168,8 @@ export function registerTmuxSessionCommands(
         return;
       }
 
-      await deps.provider.switchToTmuxSession(sessionId);
       await vscode.commands.executeCommand("opencodeTui.focus");
+      await deps.provider.switchToTmuxSession(sessionId);
     },
   );
 
@@ -180,6 +180,7 @@ export function registerTmuxSessionCommands(
         return;
       }
 
+      await vscode.commands.executeCommand("opencodeTui.focus");
       return deps.provider.createTmuxSession();
     },
   );
@@ -265,12 +266,12 @@ export function registerTmuxSessionCommands(
           return;
         }
 
+        await vscode.commands.executeCommand("opencodeTui.focus");
         if (activeBackend === "zellij") {
           await deps.provider.switchToZellijSession(picked.session.id);
         } else {
           await deps.provider.switchToTmuxSession(picked.session.id);
         }
-        await vscode.commands.executeCommand("opencodeTui.focus");
       } catch (error) {
         deps.outputChannel?.error(
           `Failed to browse tmux sessions: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/providers/MessageRouter.test.ts
+++ b/src/providers/MessageRouter.test.ts
@@ -342,6 +342,7 @@ describe("MessageRouter", () => {
       "claude",
       true,
       "%1",
+      "tmux",
     );
     expect(provider.showAiToolSelector).toHaveBeenCalledWith(
       "tmux-selected",

--- a/src/providers/MessageRouter.ts
+++ b/src/providers/MessageRouter.ts
@@ -420,14 +420,10 @@ export class MessageRouter {
     );
 
     const normalizedFiles = files.map((file) => {
-      // Normalize any URI-scheme string (file://, vscode-file://, etc.) to a
-      // filesystem path using vscode.Uri.parse so that outside-workspace
-      // absolute paths are preserved correctly before asRelativePath is called.
       if (/^[a-z][a-z0-9+\-.]*:\/\//i.test(file)) {
         try {
           return vscode.Uri.parse(file).fsPath;
         } catch {
-          // fall through to raw value
         }
       }
       return file;

--- a/src/providers/MessageRouter.ts
+++ b/src/providers/MessageRouter.ts
@@ -55,6 +55,7 @@ export interface MessageRouterProviderBridge {
     toolName: string,
     savePreference: boolean,
     targetPaneId?: string,
+    backendHint?: TerminalBackendType,
   ): Promise<void>;
   showAiToolSelector(
     sessionId: string,
@@ -163,14 +164,17 @@ export class MessageRouter {
           void this.provider.createTmuxSession();
         }
         break;
-      case "launchAiTool":
+      case "launchAiTool": {
+        const backendHint = this.provider.getActiveBackend();
         void this.provider.launchAiTool(
           message.sessionId,
           message.tool,
           message.savePreference,
           message.targetPaneId,
+          backendHint,
         );
         break;
+      }
       case "zoomTmuxPane":
         try {
           await this.provider.zoomTmuxPane();

--- a/src/providers/SessionRuntime.test.ts
+++ b/src/providers/SessionRuntime.test.ts
@@ -800,6 +800,127 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       );
     });
 
+    it("does not show AI tool selector on startOpenCode for newly created tmux session", async () => {
+      setConfiguration({
+        terminalBackend: "tmux" satisfies TerminalBackendType,
+        defaultAiTool: "opencode",
+        aiTools: [{ name: "opencode", label: "OpenCode", path: "", args: [] }],
+      });
+      upsertInstance({ workspaceUri: "file:///workspace/project-a" });
+      vi.mocked(mockTmuxSessionManager.ensureSession).mockResolvedValue({
+        action: "created" as const,
+        session: {
+          id: "project-a",
+          name: "project-a",
+          workspace: "/workspace/project-a",
+          isActive: true,
+        },
+      });
+      vi.mocked(mockTmuxSessionManager.listPanes).mockResolvedValue([
+        { paneId: "%1", isActive: true },
+      ] as unknown as Awaited<ReturnType<TmuxSessionManager["listPanes"]>>);
+      vi.mocked(mockAiToolRegistry.getForConfig).mockReturnValue({
+        getLaunchCommand: vi.fn(() => "opencode"),
+        supportsHttpApi: vi.fn(() => false),
+      } as never);
+
+      await sessionRuntime.startOpenCode();
+
+      expect(showAiToolSelectorMock).not.toHaveBeenCalled();
+    });
+
+    it("shows AI tool selector on startOpenCode when attaching to existing tmux session", async () => {
+      setConfiguration({
+        terminalBackend: "tmux" satisfies TerminalBackendType,
+        defaultAiTool: "opencode",
+        aiTools: [{ name: "opencode", label: "OpenCode", path: "", args: [] }],
+      });
+      upsertInstance({ workspaceUri: "file:///workspace/project-a" });
+      vi.mocked(mockTmuxSessionManager.ensureSession).mockResolvedValue({
+        action: "attached" as const,
+        session: {
+          id: "existing-session",
+          name: "existing-session",
+          workspace: "/workspace/project-a",
+          isActive: true,
+        },
+      });
+      vi.spyOn(
+        sessionRuntime as unknown as {
+          startExternalChangeMonitoring: (sessionId: string) => Promise<void>;
+        },
+        "startExternalChangeMonitoring",
+      ).mockResolvedValue();
+      vi.mocked(mockAiToolRegistry.getForConfig).mockReturnValue({
+        getLaunchCommand: vi.fn(() => "opencode"),
+        supportsHttpApi: vi.fn(() => false),
+      } as never);
+
+      await sessionRuntime.startOpenCode();
+
+      expect(showAiToolSelectorMock).toHaveBeenCalledWith(
+        "existing-session",
+        "existing-session",
+        true,
+      );
+    });
+
+    it("does not show AI tool selector on startOpenCode when promptAiToolOnSession is disabled", async () => {
+      setConfiguration({
+        terminalBackend: "tmux" satisfies TerminalBackendType,
+        defaultAiTool: "opencode",
+        aiTools: [{ name: "opencode", label: "OpenCode", path: "", args: [] }],
+        promptAiToolOnSession: false,
+      });
+      upsertInstance({ workspaceUri: "file:///workspace/project-a" });
+      vi.mocked(mockTmuxSessionManager.ensureSession).mockResolvedValue({
+        action: "attached" as const,
+        session: {
+          id: "existing-session",
+          name: "existing-session",
+          workspace: "/workspace/project-a",
+          isActive: true,
+        },
+      });
+      vi.spyOn(
+        sessionRuntime as unknown as {
+          startExternalChangeMonitoring: (sessionId: string) => Promise<void>;
+        },
+        "startExternalChangeMonitoring",
+      ).mockResolvedValue();
+      vi.mocked(mockAiToolRegistry.getForConfig).mockReturnValue({
+        getLaunchCommand: vi.fn(() => "opencode"),
+        supportsHttpApi: vi.fn(() => false),
+      } as never);
+
+      await sessionRuntime.startOpenCode();
+
+      expect(showAiToolSelectorMock).not.toHaveBeenCalled();
+    });
+
+    it("does not show duplicate AI tool selector when switching tmux sessions via command palette", async () => {
+      upsertInstance({ workspaceUri: "file:///workspace/project-a" });
+      vi.spyOn(
+        sessionRuntime as unknown as {
+          startExternalChangeMonitoring: (sessionId: string) => Promise<void>;
+        },
+        "startExternalChangeMonitoring",
+      ).mockResolvedValue();
+      vi.mocked(mockAiToolRegistry.getForConfig).mockReturnValue({
+        getLaunchCommand: vi.fn(() => "opencode"),
+        supportsHttpApi: vi.fn(() => false),
+      } as never);
+
+      await sessionRuntime.switchToTmuxSession("manual-tmux");
+
+      expect(showAiToolSelectorMock).toHaveBeenCalledTimes(1);
+      expect(showAiToolSelectorMock).toHaveBeenCalledWith(
+        "manual-tmux",
+        "manual-tmux",
+        true,
+      );
+    });
+
     it("prompts for an AI tool after a user attaches a tmux session", async () => {
       upsertInstance({ workspaceUri: "file:///workspace/project-a" });
       vi.spyOn(

--- a/src/providers/SessionRuntime.test.ts
+++ b/src/providers/SessionRuntime.test.ts
@@ -829,6 +829,97 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       expect(showAiToolSelectorMock).not.toHaveBeenCalled();
     });
 
+    it("warns and returns when tmux session has no panes", async () => {
+      setConfiguration({
+        terminalBackend: "tmux" satisfies TerminalBackendType,
+        defaultAiTool: "opencode",
+        aiTools: [{ name: "opencode", label: "OpenCode", path: "", args: [] }],
+      });
+      upsertInstance({ workspaceUri: "file:///workspace/project-a" });
+      vi.mocked(mockTmuxSessionManager.ensureSession).mockResolvedValue({
+        action: "created" as const,
+        session: {
+          id: "project-a",
+          name: "project-a",
+          workspace: "/workspace/project-a",
+          isActive: true,
+        },
+      });
+      vi.mocked(mockTmuxSessionManager.listPanes).mockResolvedValue([]);
+      vi.mocked(mockAiToolRegistry.getForConfig).mockReturnValue({
+        getLaunchCommand: vi.fn(() => "opencode"),
+        supportsHttpApi: vi.fn(() => false),
+      } as never);
+
+      await sessionRuntime.startOpenCode();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("no panes available"),
+      );
+      expect(mockTmuxSessionManager.sendTextToPane).not.toHaveBeenCalled();
+    });
+
+    it("warns when launching the startup tool in tmux fails", async () => {
+      setConfiguration({
+        terminalBackend: "tmux" satisfies TerminalBackendType,
+        defaultAiTool: "opencode",
+        aiTools: [{ name: "opencode", label: "OpenCode", path: "", args: [] }],
+      });
+      upsertInstance({ workspaceUri: "file:///workspace/project-a" });
+      vi.mocked(mockTmuxSessionManager.ensureSession).mockResolvedValue({
+        action: "created" as const,
+        session: {
+          id: "project-a",
+          name: "project-a",
+          workspace: "/workspace/project-a",
+          isActive: true,
+        },
+      });
+      vi.mocked(mockTmuxSessionManager.listPanes).mockRejectedValue(
+        new Error("tmux unavailable"),
+      );
+      vi.mocked(mockAiToolRegistry.getForConfig).mockReturnValue({
+        getLaunchCommand: vi.fn(() => "opencode"),
+        supportsHttpApi: vi.fn(() => false),
+      } as never);
+
+      await sessionRuntime.startOpenCode();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to launch tool in tmux session"),
+      );
+      expect(mockTmuxSessionManager.sendTextToPane).not.toHaveBeenCalled();
+    });
+
+    it("warns with a stringified non-Error when tmux launch fails", async () => {
+      setConfiguration({
+        terminalBackend: "tmux" satisfies TerminalBackendType,
+        defaultAiTool: "opencode",
+        aiTools: [{ name: "opencode", label: "OpenCode", path: "", args: [] }],
+      });
+      upsertInstance({ workspaceUri: "file:///workspace/project-a" });
+      vi.mocked(mockTmuxSessionManager.ensureSession).mockResolvedValue({
+        action: "created" as const,
+        session: {
+          id: "project-a",
+          name: "project-a",
+          workspace: "/workspace/project-a",
+          isActive: true,
+        },
+      });
+      vi.mocked(mockTmuxSessionManager.listPanes).mockRejectedValue("tmux unavailable");
+      vi.mocked(mockAiToolRegistry.getForConfig).mockReturnValue({
+        getLaunchCommand: vi.fn(() => "opencode"),
+        supportsHttpApi: vi.fn(() => false),
+      } as never);
+
+      await sessionRuntime.startOpenCode();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("tmux unavailable"),
+      );
+    });
+
     it("shows AI tool selector on startOpenCode when attaching to existing tmux session", async () => {
       setConfiguration({
         terminalBackend: "tmux" satisfies TerminalBackendType,
@@ -931,6 +1022,111 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       ).mockResolvedValue();
 
       await sessionRuntime.switchToTmuxSession("manual-tmux");
+
+      expect(showAiToolSelectorMock).toHaveBeenCalledWith(
+        "manual-tmux",
+        "manual-tmux",
+        true,
+      );
+    });
+
+    it("does not prompt for an AI tool when forceToolPrompt is disabled", async () => {
+      upsertInstance({ workspaceUri: "file:///workspace/project-a" });
+      vi.spyOn(
+        sessionRuntime as unknown as {
+          startExternalChangeMonitoring: (sessionId: string) => Promise<void>;
+        },
+        "startExternalChangeMonitoring",
+      ).mockResolvedValue();
+
+      await sessionRuntime.switchToTmuxSessionWithTool("manual-tmux", undefined, {
+        forceToolPrompt: false,
+        respectPromptAiToolOnSession: true,
+      });
+
+      expect(showAiToolSelectorMock).not.toHaveBeenCalled();
+    });
+
+    it("does not prompt for an AI tool when a preferred tool is already selected", async () => {
+      upsertInstance({ workspaceUri: "file:///workspace/project-a" });
+      vi.spyOn(
+        sessionRuntime as unknown as {
+          startExternalChangeMonitoring: (sessionId: string) => Promise<void>;
+        },
+        "startExternalChangeMonitoring",
+      ).mockResolvedValue();
+
+      await sessionRuntime.switchToTmuxSessionWithTool(
+        "manual-tmux",
+        "preferred-tool",
+        {
+          forceToolPrompt: true,
+          respectPromptAiToolOnSession: true,
+        },
+      );
+
+      expect(showAiToolSelectorMock).not.toHaveBeenCalled();
+    });
+
+    it("does not prompt for an AI tool when the session prompt setting is disabled", async () => {
+      setConfiguration({
+        promptAiToolOnSession: false,
+      });
+      upsertInstance({ workspaceUri: "file:///workspace/project-a" });
+      vi.spyOn(
+        sessionRuntime as unknown as {
+          startExternalChangeMonitoring: (sessionId: string) => Promise<void>;
+        },
+        "startExternalChangeMonitoring",
+      ).mockResolvedValue();
+
+      await sessionRuntime.switchToTmuxSessionWithTool("manual-tmux", undefined, {
+        forceToolPrompt: true,
+        respectPromptAiToolOnSession: true,
+      });
+
+      expect(showAiToolSelectorMock).not.toHaveBeenCalled();
+    });
+
+    it("shows the AI tool selector when prompt preference is not respected", async () => {
+      setConfiguration({
+        promptAiToolOnSession: false,
+      });
+      upsertInstance({ workspaceUri: "file:///workspace/project-a" });
+      vi.spyOn(
+        sessionRuntime as unknown as {
+          startExternalChangeMonitoring: (sessionId: string) => Promise<void>;
+        },
+        "startExternalChangeMonitoring",
+      ).mockResolvedValue();
+
+      await sessionRuntime.switchToTmuxSessionWithTool("manual-tmux", undefined, {
+        forceToolPrompt: true,
+        respectPromptAiToolOnSession: false,
+      });
+
+      expect(showAiToolSelectorMock).toHaveBeenCalledWith(
+        "manual-tmux",
+        "manual-tmux",
+        true,
+      );
+    });
+
+    it("shows the AI tool selector when prompt preference is omitted", async () => {
+      setConfiguration({
+        promptAiToolOnSession: false,
+      });
+      upsertInstance({ workspaceUri: "file:///workspace/project-a" });
+      vi.spyOn(
+        sessionRuntime as unknown as {
+          startExternalChangeMonitoring: (sessionId: string) => Promise<void>;
+        },
+        "startExternalChangeMonitoring",
+      ).mockResolvedValue();
+
+      await sessionRuntime.switchToTmuxSessionWithTool("manual-tmux", undefined, {
+        forceToolPrompt: true,
+      });
 
       expect(showAiToolSelectorMock).toHaveBeenCalledWith(
         "manual-tmux",
@@ -1599,6 +1795,22 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
         sessionId: "workspace-session",
         backend: "tmux",
       });
+    });
+
+    it("withLaunchEnvironment prepends port env vars when port is provided", () => {
+      const runtime = sessionRuntime as unknown as {
+        withLaunchEnvironment: (
+          command: string,
+          port: number | undefined,
+        ) => string;
+      };
+
+      expect(runtime.withLaunchEnvironment("opencode", 30000)).toBe(
+        "_EXTENSION_OPENCODE_PORT=30000 OPENCODE_CALLER=vscode opencode",
+      );
+      expect(runtime.withLaunchEnvironment("opencode", undefined)).toBe(
+        "opencode",
+      );
     });
   });
 

--- a/src/providers/SessionRuntime.test.ts
+++ b/src/providers/SessionRuntime.test.ts
@@ -2895,7 +2895,9 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
 
       await sessionRuntime.selectTerminalBackend("tmux");
 
-      expect(switchSpy).toHaveBeenCalledWith("project-a");
+      expect(switchSpy).toHaveBeenCalledWith("project-a", undefined, {
+        forceToolPrompt: true,
+      });
     });
 
     it("starts with an existing valid stored zellij session", async () => {

--- a/src/providers/SessionRuntime.test.ts
+++ b/src/providers/SessionRuntime.test.ts
@@ -449,7 +449,7 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       } as Awaited<ReturnType<TmuxSessionManager["findSessionForWorkspace"]>>);
 
       const switchSpy = vi
-        .spyOn(sessionRuntime, "switchToTmuxSession")
+        .spyOn(sessionRuntime, "switchToTmuxSessionWithTool")
         .mockResolvedValue();
 
       sessionRuntime.reconnectListeners();
@@ -797,6 +797,24 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
         undefined,
         "default",
         "/workspace/project-a",
+      );
+    });
+
+    it("prompts for an AI tool after a user attaches a tmux session", async () => {
+      upsertInstance({ workspaceUri: "file:///workspace/project-a" });
+      vi.spyOn(
+        sessionRuntime as unknown as {
+          startExternalChangeMonitoring: (sessionId: string) => Promise<void>;
+        },
+        "startExternalChangeMonitoring",
+      ).mockResolvedValue();
+
+      await sessionRuntime.switchToTmuxSession("manual-tmux");
+
+      expect(showAiToolSelectorMock).toHaveBeenCalledWith(
+        "manual-tmux",
+        "manual-tmux",
+        true,
       );
     });
 
@@ -1648,7 +1666,9 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
         "project-a-3",
         "/workspace/project-a",
       );
-      expect(switchSpy).toHaveBeenCalledWith("project-a-3");
+      expect(switchSpy).toHaveBeenCalledWith("project-a-3", undefined, {
+        forceToolPrompt: true,
+      });
     });
 
     it("zooms the active pane", async () => {
@@ -1709,7 +1729,7 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       } as Awaited<ReturnType<TmuxSessionManager["findSessionForWorkspace"]>>);
 
       const switchSpy = vi
-        .spyOn(sessionRuntime, "switchToTmuxSession")
+        .spyOn(sessionRuntime, "switchToTmuxSessionWithTool")
         .mockResolvedValue();
 
       await sessionRuntime.killTmuxSession("workspace-session");
@@ -1720,7 +1740,9 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       expect(
         instanceStore.get("default")?.runtime.tmuxSessionId,
       ).toBeUndefined();
-      expect(switchSpy).toHaveBeenCalledWith("replacement-session");
+      expect(switchSpy).toHaveBeenCalledWith("replacement-session", undefined, {
+        forceToolPrompt: true,
+      });
       expect(mockPortManager.releaseTerminalPorts).toHaveBeenCalledWith(
         "default",
       );
@@ -2868,7 +2890,7 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
         },
       });
       const switchSpy = vi
-        .spyOn(sessionRuntime, "switchToTmuxSession")
+        .spyOn(sessionRuntime, "switchToTmuxSessionWithTool")
         .mockResolvedValue();
 
       await sessionRuntime.selectTerminalBackend("tmux");

--- a/src/providers/SessionRuntime.test.ts
+++ b/src/providers/SessionRuntime.test.ts
@@ -1668,6 +1668,7 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       );
       expect(switchSpy).toHaveBeenCalledWith("project-a-3", undefined, {
         forceToolPrompt: true,
+        respectPromptAiToolOnSession: true,
       });
     });
 
@@ -1742,6 +1743,7 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       ).toBeUndefined();
       expect(switchSpy).toHaveBeenCalledWith("replacement-session", undefined, {
         forceToolPrompt: true,
+        respectPromptAiToolOnSession: true,
       });
       expect(mockPortManager.releaseTerminalPorts).toHaveBeenCalledWith(
         "default",

--- a/src/providers/SessionRuntime.test.ts
+++ b/src/providers/SessionRuntime.test.ts
@@ -3106,12 +3106,26 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
 
       await sessionRuntime.switchToZellijSession("zellij-session");
 
+      expect(showAiToolSelectorMock).toHaveBeenCalledWith(
+        "zellij-session",
+        "zellij-session",
+        true,
+      );
       expect(mockLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining("Failed to switch zellij session"),
       );
       expect(mockLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining("Failed to start zellij change monitoring"),
       );
+    });
+
+    it("skips zellij AI tool selector when promptAiToolOnSession is disabled", async () => {
+      setConfiguration({ promptAiToolOnSession: false });
+      vi.spyOn(sessionRuntime, "switchToInstance").mockResolvedValue();
+
+      await sessionRuntime.switchToZellijSession("zellij-session");
+
+      expect(showAiToolSelectorMock).not.toHaveBeenCalled();
     });
 
     it("posts terminalExited when attached tmux restoration fails", async () => {

--- a/src/providers/SessionRuntime.test.ts
+++ b/src/providers/SessionRuntime.test.ts
@@ -2898,6 +2898,13 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       expect(switchSpy).toHaveBeenCalledWith("project-a", undefined, {
         forceToolPrompt: true,
       });
+      expect(
+        (
+          sessionRuntime as unknown as {
+            tmuxSessionsCreatedForStartup: Set<string>;
+          }
+        ).tmuxSessionsCreatedForStartup.has("project-a"),
+      ).toBe(false);
     });
 
     it("starts with an existing valid stored zellij session", async () => {

--- a/src/providers/SessionRuntime.test.ts
+++ b/src/providers/SessionRuntime.test.ts
@@ -758,6 +758,48 @@ describe("SessionRuntime - Workspace Session Resolution", () => {
       );
     });
 
+    it("launches the startup tool inside newly created tmux workspace sessions", async () => {
+      setConfiguration({
+        terminalBackend: "tmux" satisfies TerminalBackendType,
+        defaultAiTool: "opencode",
+        aiTools: [{ name: "opencode", label: "OpenCode", path: "", args: [] }],
+      });
+      upsertInstance({ workspaceUri: "file:///workspace/project-a" });
+      vi.mocked(mockTmuxSessionManager.ensureSession).mockResolvedValue({
+        action: "created" as const,
+        session: {
+          id: "project-a",
+          name: "project-a",
+          workspace: "/workspace/project-a",
+          isActive: true,
+        },
+      });
+      vi.mocked(mockTmuxSessionManager.listPanes).mockResolvedValue([
+        { paneId: "%1", isActive: true },
+      ] as unknown as Awaited<ReturnType<TmuxSessionManager["listPanes"]>>);
+      vi.mocked(mockAiToolRegistry.getForConfig).mockReturnValue({
+        getLaunchCommand: vi.fn(() => "opencode"),
+        supportsHttpApi: vi.fn(() => false),
+      } as never);
+
+      await sessionRuntime.startOpenCode();
+
+      expect(mockTmuxSessionManager.sendTextToPane).toHaveBeenCalledWith(
+        "%1",
+        "opencode",
+      );
+      expect(mockTerminalManager.createTerminal).toHaveBeenCalledWith(
+        "default",
+        "tmux attach-session -t project-a \\; set-option -u status off",
+        {},
+        undefined,
+        undefined,
+        undefined,
+        "default",
+        "/workspace/project-a",
+      );
+    });
+
     it("reuses an existing terminal for an instance and restores HTTP listeners", async () => {
       upsertInstance({ id: "instance-2", selectedAiTool: "preferred-tool" });
       sessionRuntime.setLastKnownTerminalSize(120, 40);

--- a/src/providers/SessionRuntime.ts
+++ b/src/providers/SessionRuntime.ts
@@ -466,11 +466,18 @@ export class SessionRuntime {
         }
       }
 
+      const wasTmuxCreatedForStartup =
+        !!tmuxSessionId &&
+        this.tmuxSessionsCreatedForStartup.has(tmuxSessionId);
+
       await this.launchToolInCreatedTmuxSession(
         tmuxSessionId,
         command,
         port,
       );
+
+      const wasManualSessionSelection =
+        !!this.selectedTmuxSessionId || !!this.selectedZellijSessionId;
 
       this.selectedTmuxSessionId = undefined;
       this.selectedZellijSessionId = undefined;
@@ -558,9 +565,39 @@ export class SessionRuntime {
         );
         this.httpAvailable = false;
       }
+
+      this.maybeShowAiToolSelectorOnExistingSession(
+        tmuxSessionId,
+        zellijSessionId,
+        wasTmuxCreatedForStartup,
+        wasManualSessionSelection,
+      );
     } finally {
       this.isStarting = false;
     }
+  }
+
+  private maybeShowAiToolSelectorOnExistingSession(
+    tmuxSessionId: string | undefined,
+    zellijSessionId: string | undefined,
+    wasTmuxCreatedForStartup: boolean,
+    wasManualSessionSelection: boolean,
+  ): void {
+    const sessionId = tmuxSessionId ?? zellijSessionId;
+    if (!sessionId) {
+      return;
+    }
+    if (tmuxSessionId && wasTmuxCreatedForStartup) {
+      return;
+    }
+    if (wasManualSessionSelection) {
+      return;
+    }
+    const config = vscode.workspace.getConfiguration("opencodeTui");
+    if (!config.get<boolean>("promptAiToolOnSession", true)) {
+      return;
+    }
+    this.callbacks.showAiToolSelector(sessionId, sessionId, true);
   }
 
   public restart(): void {

--- a/src/providers/SessionRuntime.ts
+++ b/src/providers/SessionRuntime.ts
@@ -1119,15 +1119,10 @@ export class SessionRuntime {
       const instanceId = this.resolveInstanceIdFromSessionId(sessionId);
       this.persistSelectedTool(preferredToolName, instanceId);
     }
-    await this.switchToInstance(
-      this.resolveInstanceIdFromSessionId(sessionId),
-      {
-        forceRestart: true,
-        preferredToolName,
-      },
-    );
-    this.notifyActiveSession(sessionId);
-    if (options.forceToolPrompt && !preferredToolName) {
+
+    const shouldShowSelector =
+      options.forceToolPrompt && !preferredToolName;
+    if (shouldShowSelector) {
       const config = vscode.workspace.getConfiguration("opencodeTui");
       if (
         !options.respectPromptAiToolOnSession ||
@@ -1136,6 +1131,15 @@ export class SessionRuntime {
         this.callbacks.showAiToolSelector(sessionId, sessionId, true);
       }
     }
+
+    await this.switchToInstance(
+      this.resolveInstanceIdFromSessionId(sessionId),
+      {
+        forceRestart: true,
+        preferredToolName,
+      },
+    );
+    this.notifyActiveSession(sessionId);
   }
 
   public async switchToZellijSession(sessionId: string): Promise<void> {

--- a/src/providers/SessionRuntime.ts
+++ b/src/providers/SessionRuntime.ts
@@ -166,7 +166,9 @@ export class SessionRuntime {
     if (resolved === "tmux") {
       const sessionId = await this.ensureTmuxBackendSession();
       if (sessionId) {
-        await this.switchToTmuxSessionWithTool(sessionId);
+        await this.switchToTmuxSessionWithTool(sessionId, undefined, {
+          forceToolPrompt: true,
+        });
         return;
       }
       void vscode.window.showWarningMessage(

--- a/src/providers/SessionRuntime.ts
+++ b/src/providers/SessionRuntime.ts
@@ -166,7 +166,7 @@ export class SessionRuntime {
     if (resolved === "tmux") {
       const sessionId = await this.ensureTmuxBackendSession();
       if (sessionId) {
-        await this.switchToTmuxSession(sessionId);
+        await this.switchToTmuxSessionWithTool(sessionId);
         return;
       }
       void vscode.window.showWarningMessage(
@@ -660,7 +660,7 @@ export class SessionRuntime {
         : undefined;
 
       if (replacementSessionId) {
-        await this.switchToTmuxSession(replacementSessionId);
+        await this.switchToTmuxSessionWithTool(replacementSessionId);
         return;
       }
 
@@ -1033,12 +1033,15 @@ export class SessionRuntime {
   }
 
   public async switchToTmuxSession(sessionId: string): Promise<void> {
-    await this.switchToTmuxSessionWithTool(sessionId);
+    await this.switchToTmuxSessionWithTool(sessionId, undefined, {
+      forceToolPrompt: true,
+    });
   }
 
   public async switchToTmuxSessionWithTool(
     sessionId: string,
     preferredToolName?: string,
+    options: { forceToolPrompt?: boolean } = {},
   ): Promise<void> {
     this.forceNativeShellNextStart = false;
     this.pendingBackendOverride = "tmux";
@@ -1078,6 +1081,9 @@ export class SessionRuntime {
       },
     );
     this.notifyActiveSession(sessionId);
+    if (options.forceToolPrompt && !preferredToolName) {
+      this.callbacks.showAiToolSelector(sessionId, sessionId, true);
+    }
   }
 
   public async switchToZellijSession(sessionId: string): Promise<void> {
@@ -1162,7 +1168,9 @@ export class SessionRuntime {
       }
 
       await this.tmuxSessionManager.createSession(candidate, workspacePath);
-      await this.switchToTmuxSessionWithTool(candidate);
+      await this.switchToTmuxSessionWithTool(candidate, undefined, {
+        forceToolPrompt: true,
+      });
 
       return candidate;
     } catch (error) {

--- a/src/providers/SessionRuntime.ts
+++ b/src/providers/SessionRuntime.ts
@@ -556,6 +556,13 @@ export class SessionRuntime {
         this.activeBackend,
       );
 
+      this.maybeShowAiToolSelectorOnExistingSession(
+        tmuxSessionId,
+        zellijSessionId,
+        wasTmuxCreatedForStartup,
+        wasManualSessionSelection,
+      );
+
       if (enableHttpApi && port) {
         this.apiClient = new OpenCodeApiClient(port, 10, 200, httpTimeout);
         await this.pollForHttpReadiness();
@@ -565,13 +572,6 @@ export class SessionRuntime {
         );
         this.httpAvailable = false;
       }
-
-      this.maybeShowAiToolSelectorOnExistingSession(
-        tmuxSessionId,
-        zellijSessionId,
-        wasTmuxCreatedForStartup,
-        wasManualSessionSelection,
-      );
     } finally {
       this.isStarting = false;
     }

--- a/src/providers/SessionRuntime.ts
+++ b/src/providers/SessionRuntime.ts
@@ -963,7 +963,6 @@ export class SessionRuntime {
         return undefined;
       }
 
-      // Prefer the active session only if it matches the current workspace
       const workspaceBasename = workspacePath
         ? path.basename(workspacePath)
         : undefined;
@@ -980,7 +979,6 @@ export class SessionRuntime {
         if (matchingAny) {
           return matchingAny.id;
         }
-        // No workspace-matched session; do NOT attach to an unrelated session
         return undefined;
       }
 
@@ -1561,7 +1559,6 @@ export class SessionRuntime {
     try {
       this.activeInstanceId = this.instanceStore.getActive().config.id;
     } catch {
-      // No active instance yet — use default
     }
 
     this.activeInstanceSubscription = this.instanceStore.onDidSetActive(
@@ -1581,7 +1578,6 @@ export class SessionRuntime {
         this.instanceStore.setActive(instanceId);
       }
     } catch {
-      // No active instance — nothing to sync
     }
   }
 
@@ -1626,7 +1622,6 @@ export class SessionRuntime {
           await vscode.env.clipboard.writeText(buf);
         }
       } catch {
-        // Clipboard sync is best-effort; skip this cycle
       }
     }, 500);
   }

--- a/src/providers/SessionRuntime.ts
+++ b/src/providers/SessionRuntime.ts
@@ -71,6 +71,7 @@ export class SessionRuntime {
   private sigusr2FiredSinceLastCheck = false;
   private externalChangeListener?: vscode.Disposable;
   private paneMonitorInterval?: ReturnType<typeof setInterval>;
+  private readonly tmuxSessionsCreatedForStartup = new Set<string>();
 
   public constructor(
     private readonly terminalManager: TerminalManager,
@@ -439,15 +440,9 @@ export class SessionRuntime {
         zellijSessionId,
       );
 
-      let port: number | undefined;
-      this.selectedTmuxSessionId = undefined;
-      this.selectedZellijSessionId = undefined;
-      this.pendingBackendOverride = undefined;
-      this.forceNativeShellNextStart = false;
-      this.pendingLaunchToolName = undefined;
-
       const activeOperator =
         this.activeTool && this.aiToolRegistry.getForConfig(this.activeTool);
+      let port: number | undefined;
       if (
         enableHttpApi &&
         command !== undefined &&
@@ -468,6 +463,18 @@ export class SessionRuntime {
           );
         }
       }
+
+      await this.launchToolInCreatedTmuxSession(
+        tmuxSessionId,
+        command,
+        port,
+      );
+
+      this.selectedTmuxSessionId = undefined;
+      this.selectedZellijSessionId = undefined;
+      this.pendingBackendOverride = undefined;
+      this.forceNativeShellNextStart = false;
+      this.pendingLaunchToolName = undefined;
 
       this.terminalManager.createTerminal(
         this.activeInstanceId,
@@ -758,6 +765,9 @@ export class SessionRuntime {
       this.logger.info(
         `[TerminalProvider] tmux session ${result.action}: ${result.session.id}`,
       );
+      if (result.action === "created") {
+        this.tmuxSessionsCreatedForStartup.add(result.session.id);
+      }
       return result.session.id;
     } catch (error) {
       if (error instanceof TmuxUnavailableError) {
@@ -786,6 +796,45 @@ export class SessionRuntime {
       return this.zellijSessionManager.getAttachCommand(zellijSessionId);
     }
     return defaultCommand;
+  }
+
+  private async launchToolInCreatedTmuxSession(
+    sessionId: string | undefined,
+    command: string | undefined,
+    port: number | undefined,
+  ): Promise<void> {
+    if (!sessionId || !command || !this.tmuxSessionManager) {
+      return;
+    }
+    if (!this.tmuxSessionsCreatedForStartup.delete(sessionId)) {
+      return;
+    }
+
+    try {
+      const panes = await this.tmuxSessionManager.listPanes(sessionId);
+      const targetPane = panes.find((pane) => pane.isActive) ?? panes[0];
+      if (!targetPane) {
+        this.logger.warn(
+          `[TerminalProvider] Cannot launch tool in tmux session '${sessionId}': no panes available`,
+        );
+        return;
+      }
+      await this.tmuxSessionManager.sendTextToPane(
+        targetPane.paneId,
+        this.withLaunchEnvironment(command, port),
+      );
+    } catch (error) {
+      this.logger.warn(
+        `[TerminalProvider] Failed to launch tool in tmux session '${sessionId}': ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  private withLaunchEnvironment(command: string, port: number | undefined): string {
+    if (!port) {
+      return command;
+    }
+    return `_EXTENSION_OPENCODE_PORT=${port} OPENCODE_CALLER=vscode ${command}`;
   }
 
   public resolveConfiguredBackend(

--- a/src/providers/SessionRuntime.ts
+++ b/src/providers/SessionRuntime.ts
@@ -752,6 +752,7 @@ export class SessionRuntime {
 
   public async ensureWorkspaceSession(
     workspacePath: string,
+    options: { trackCreatedForStartup?: boolean } = {},
   ): Promise<string | undefined> {
     if (!this.tmuxSessionManager) {
       return undefined;
@@ -767,7 +768,7 @@ export class SessionRuntime {
       this.logger.info(
         `[TerminalProvider] tmux session ${result.action}: ${result.session.id}`,
       );
-      if (result.action === "created") {
+      if (options.trackCreatedForStartup !== false && result.action === "created") {
         this.tmuxSessionsCreatedForStartup.add(result.session.id);
       }
       return result.session.id;
@@ -984,7 +985,9 @@ export class SessionRuntime {
 
   private async ensureTmuxBackendSession(): Promise<string | undefined> {
     const { workspacePath } = this.resolveStartupWorkspacePath();
-    return this.ensureWorkspaceSession(workspacePath);
+    return this.ensureWorkspaceSession(workspacePath, {
+      trackCreatedForStartup: false,
+    });
   }
 
   private async ensureZellijBackendSession(): Promise<string | undefined> {

--- a/src/providers/SessionRuntime.ts
+++ b/src/providers/SessionRuntime.ts
@@ -1165,6 +1165,12 @@ export class SessionRuntime {
         );
       }
     }
+
+    const config = vscode.workspace.getConfiguration("opencodeTui");
+    if (config.get<boolean>("promptAiToolOnSession", true)) {
+      this.callbacks.showAiToolSelector(sessionId, sessionId, true);
+    }
+
     await this.switchToInstance(
       this.resolveInstanceIdFromSessionId(sessionId),
       {

--- a/src/providers/SessionRuntime.ts
+++ b/src/providers/SessionRuntime.ts
@@ -1040,13 +1040,17 @@ export class SessionRuntime {
   public async switchToTmuxSession(sessionId: string): Promise<void> {
     await this.switchToTmuxSessionWithTool(sessionId, undefined, {
       forceToolPrompt: true,
+      respectPromptAiToolOnSession: true,
     });
   }
 
   public async switchToTmuxSessionWithTool(
     sessionId: string,
     preferredToolName?: string,
-    options: { forceToolPrompt?: boolean } = {},
+    options: {
+      forceToolPrompt?: boolean;
+      respectPromptAiToolOnSession?: boolean;
+    } = {},
   ): Promise<void> {
     this.forceNativeShellNextStart = false;
     this.pendingBackendOverride = "tmux";
@@ -1087,7 +1091,13 @@ export class SessionRuntime {
     );
     this.notifyActiveSession(sessionId);
     if (options.forceToolPrompt && !preferredToolName) {
-      this.callbacks.showAiToolSelector(sessionId, sessionId, true);
+      const config = vscode.workspace.getConfiguration("opencodeTui");
+      if (
+        !options.respectPromptAiToolOnSession ||
+        config.get<boolean>("promptAiToolOnSession", true)
+      ) {
+        this.callbacks.showAiToolSelector(sessionId, sessionId, true);
+      }
     }
   }
 
@@ -1175,6 +1185,7 @@ export class SessionRuntime {
       await this.tmuxSessionManager.createSession(candidate, workspacePath);
       await this.switchToTmuxSessionWithTool(candidate, undefined, {
         forceToolPrompt: true,
+        respectPromptAiToolOnSession: true,
       });
 
       return candidate;

--- a/src/providers/TerminalDashboardProvider.test.ts
+++ b/src/providers/TerminalDashboardProvider.test.ts
@@ -46,6 +46,7 @@ describe("TerminalDashboardProvider", () => {
     zellijDiscoverSessions?: ReturnType<typeof vi.fn>;
     zellijListPanes?: ReturnType<typeof vi.fn>;
     zellijListTabs?: ReturnType<typeof vi.fn>;
+    zellijSwitchSession?: ReturnType<typeof vi.fn>;
     instanceStore?: {
       getAll: ReturnType<typeof vi.fn>;
       getActive?: ReturnType<typeof vi.fn>;
@@ -76,6 +77,8 @@ describe("TerminalDashboardProvider", () => {
     const zellijDiscoverSessions = options?.zellijDiscoverSessions;
     const zellijListPanes = options?.zellijListPanes ?? vi.fn().mockResolvedValue([]);
     const zellijListTabs = options?.zellijListTabs ?? vi.fn().mockResolvedValue([]);
+    const zellijSwitchSession =
+      options?.zellijSwitchSession ?? vi.fn().mockResolvedValue(undefined);
     const logger =
       options?.logger ??
       ({
@@ -118,6 +121,7 @@ describe("TerminalDashboardProvider", () => {
           splitPane: vi.fn().mockResolvedValue("terminal_8"),
           killPane: vi.fn().mockResolvedValue(undefined),
           resizePane: vi.fn().mockResolvedValue(undefined),
+          switchSession: zellijSwitchSession,
         }
       : undefined;
 
@@ -128,6 +132,7 @@ describe("TerminalDashboardProvider", () => {
       listWindowPaneGeometry,
       zellijListPanes,
       zellijListTabs,
+      zellijSwitchSession,
       logger,
       instanceStore,
       terminalProvider,
@@ -1061,6 +1066,28 @@ describe("TerminalDashboardProvider", () => {
     expect(zellijSessionManager?.killPane).toHaveBeenCalled();
   });
 
+  it("switches into the zellij session before zellij actions", async () => {
+    const zellijSwitchSession = vi.fn().mockResolvedValue(undefined);
+    const { provider } = createProvider({
+      discoverSessions: vi.fn().mockResolvedValue([]),
+      zellijDiscoverSessions: vi.fn().mockResolvedValue([
+        { id: "repo-a", name: "repo-a", workspace: "repo-a", isActive: true },
+      ]),
+      zellijListPanes: vi.fn().mockResolvedValue([]),
+      zellijListTabs: vi.fn().mockResolvedValue([
+        { index: 1, name: "main", isActive: true },
+      ]),
+      zellijSwitchSession,
+    });
+
+    const { messageHandler } = resolveProvider(provider);
+    await flushPromises();
+
+    await messageHandler({ action: "nextWindow", sessionId: "repo-a" });
+
+    expect(zellijSwitchSession).toHaveBeenCalledWith("repo-a");
+  });
+
   it("uses the active pane target when opening the AI selector and falls back gracefully on pane lookup errors", async () => {
     const showAiToolSelector = vi.fn();
     const terminalProvider = {
@@ -1156,6 +1183,27 @@ describe("TerminalDashboardProvider", () => {
         sessionId: "repo-a",
         targetPaneId: "%7",
       }),
+    );
+  });
+
+  it("falls back to terminal provider when dashboard webview postMessage returns false", async () => {
+    const terminalProvider = {
+      showAiToolSelector: vi.fn(),
+      launchAiTool: vi.fn(),
+    };
+    const { provider } = createProvider({ terminalProvider });
+
+    const { view } = resolveProvider(provider);
+    await flushPromises();
+    vi.mocked(view.webview.postMessage).mockResolvedValue(false);
+
+    await provider.showAiToolSelector("repo-a", "Repo A", true, "%1");
+
+    expect(terminalProvider.showAiToolSelector).toHaveBeenCalledWith(
+      "repo-a",
+      "Repo A",
+      true,
+      "%1",
     );
   });
 
@@ -2132,5 +2180,14 @@ describe("TerminalDashboardProvider", () => {
     (
       fresh.provider as unknown as { flushPendingMessage: () => void }
     ).flushPendingMessage();
+  });
+
+  it("ensureZellijSession is a no-op when zellijSessionManager is not available", async () => {
+    const { provider } = createProvider({ zellijDiscoverSessions: undefined });
+    await (
+      provider as unknown as {
+        ensureZellijSession: (id: string) => Promise<void>;
+      }
+    ).ensureZellijSession("missing-session");
   });
 });

--- a/src/providers/TerminalDashboardProvider.test.ts
+++ b/src/providers/TerminalDashboardProvider.test.ts
@@ -976,6 +976,7 @@ describe("TerminalDashboardProvider", () => {
       "claude",
       true,
       undefined,
+      "tmux",
     );
   });
 
@@ -1646,6 +1647,7 @@ describe("TerminalDashboardProvider", () => {
       "claude",
       true,
       "terminal_2",
+      "zellij",
     );
 
     const noTerminalProvider = createProvider();

--- a/src/providers/TerminalDashboardProvider.test.ts
+++ b/src/providers/TerminalDashboardProvider.test.ts
@@ -450,8 +450,9 @@ describe("TerminalDashboardProvider", () => {
     });
     const splitPane = vi.mocked(tmuxSessionManager.splitPane);
     splitPane.mockResolvedValue("%8");
-    const { messageHandler } = resolveProvider(provider);
+    const { view, messageHandler } = resolveProvider(provider);
     await flushPromises();
+    vi.mocked(view.webview.postMessage).mockClear();
 
     await messageHandler({
       action: "splitPane",
@@ -850,8 +851,9 @@ describe("TerminalDashboardProvider", () => {
       instanceStore,
     });
 
-    const { messageHandler } = resolveProvider(provider);
+    const { view, messageHandler } = resolveProvider(provider);
     await flushPromises();
+    vi.mocked(view.webview.postMessage).mockClear();
     vi.mocked(vscode.commands.executeCommand).mockClear();
 
     await messageHandler({
@@ -888,8 +890,9 @@ describe("TerminalDashboardProvider", () => {
       terminalProvider,
     });
 
-    const { messageHandler } = resolveProvider(provider);
+    const { view, messageHandler } = resolveProvider(provider);
     await flushPromises();
+    vi.mocked(view.webview.postMessage).mockClear();
 
     await messageHandler({ action: "createWindow", sessionId: "repo-a" });
     await messageHandler({ action: "nextWindow", sessionId: "repo-a" });
@@ -1002,8 +1005,9 @@ describe("TerminalDashboardProvider", () => {
       terminalProvider,
     });
 
-    const { messageHandler } = resolveProvider(provider);
+    const { view, messageHandler } = resolveProvider(provider);
     await flushPromises();
+    vi.mocked(view.webview.postMessage).mockClear();
 
     await messageHandler({ action: "activate", sessionId: "repo-a" });
     await messageHandler({ action: "createWindow", sessionId: "repo-a" });
@@ -1084,8 +1088,9 @@ describe("TerminalDashboardProvider", () => {
       terminalProvider,
     });
 
-    const { messageHandler } = resolveProvider(provider);
+    const { view, messageHandler } = resolveProvider(provider);
     await flushPromises();
+    vi.mocked(view.webview.postMessage).mockClear();
 
     await messageHandler({
       action: "showAiToolSelector",
@@ -1098,23 +1103,26 @@ describe("TerminalDashboardProvider", () => {
       sessionName: "Repo A",
     });
 
-    expect(showAiToolSelector).toHaveBeenNthCalledWith(
+    expect(showAiToolSelector).not.toHaveBeenCalled();
+    expect(view.webview.postMessage).toHaveBeenNthCalledWith(
       1,
-      "repo-a",
-      "Repo A",
-      true,
-      "%9",
+      expect.objectContaining({
+        type: "showAiToolSelector",
+        sessionId: "repo-a",
+        targetPaneId: "%9",
+      }),
     );
-    expect(showAiToolSelector).toHaveBeenNthCalledWith(
+    expect(view.webview.postMessage).toHaveBeenNthCalledWith(
       2,
-      "repo-a",
-      "Repo A",
-      true,
-      undefined,
+      expect.objectContaining({
+        type: "showAiToolSelector",
+        sessionId: "repo-a",
+        targetPaneId: undefined,
+      }),
     );
   });
 
-  it("delegates AI selector display directly to TerminalProvider when available", async () => {
+  it("falls back to TerminalProvider for selector display before the dashboard webview resolves", async () => {
     const terminalProvider = {
       showAiToolSelector: vi.fn(),
       launchAiTool: vi.fn(),
@@ -1609,8 +1617,9 @@ describe("TerminalDashboardProvider", () => {
       terminalProvider,
     });
 
-    const { messageHandler } = resolveProvider(provider);
+    const { view, messageHandler } = resolveProvider(provider);
     await flushPromises();
+    vi.mocked(view.webview.postMessage).mockClear();
     await messageHandler({
       action: "showAiToolSelector",
       sessionId: "zellij-a",
@@ -1624,11 +1633,13 @@ describe("TerminalDashboardProvider", () => {
       targetPaneId: "terminal_2",
     });
 
-    expect(terminalProvider.showAiToolSelector).toHaveBeenCalledWith(
-      "zellij-a",
-      "Zellij A",
-      true,
-      "terminal_2",
+    expect(terminalProvider.showAiToolSelector).not.toHaveBeenCalled();
+    expect(view.webview.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "showAiToolSelector",
+        sessionId: "zellij-a",
+        targetPaneId: "terminal_2",
+      }),
     );
     expect(terminalProvider.launchAiTool).toHaveBeenCalledWith(
       "zellij-a",

--- a/src/providers/TerminalDashboardProvider.test.ts
+++ b/src/providers/TerminalDashboardProvider.test.ts
@@ -1634,7 +1634,7 @@ describe("TerminalDashboardProvider", () => {
       "zellij-a",
       "claude",
       true,
-      undefined,
+      "terminal_2",
     );
 
     const noTerminalProvider = createProvider();

--- a/src/providers/TerminalDashboardProvider.ts
+++ b/src/providers/TerminalDashboardProvider.ts
@@ -774,6 +774,24 @@ export class TerminalDashboardProvider
     forceShow = false,
     targetPaneId?: string,
   ): Promise<void> {
+    const webview = this.getActiveWebview();
+    if (webview) {
+      const config = vscode.workspace.getConfiguration("opencodeTui");
+      const tools: AiToolConfig[] = resolveAiToolConfigs(
+        config.get("aiTools", []),
+      );
+
+      await webview.postMessage({
+        type: "showAiToolSelector",
+        sessionId,
+        sessionName,
+        defaultTool: undefined,
+        tools,
+        targetPaneId,
+      } satisfies TmuxDashboardHostMessage);
+      return;
+    }
+
     if (this.terminalProvider) {
       this.terminalProvider.showAiToolSelector(
         sessionId,
@@ -783,25 +801,6 @@ export class TerminalDashboardProvider
       );
       return;
     }
-
-    const webview = this.getActiveWebview();
-    if (!webview) {
-      return;
-    }
-
-    const config = vscode.workspace.getConfiguration("opencodeTui");
-    const tools: AiToolConfig[] = resolveAiToolConfigs(
-      config.get("aiTools", []),
-    );
-
-    await webview.postMessage({
-      type: "showAiToolSelector",
-      sessionId,
-      sessionName,
-      defaultTool: undefined,
-      tools,
-      targetPaneId,
-    } satisfies TmuxDashboardHostMessage);
   }
 
   /**

--- a/src/providers/TerminalDashboardProvider.ts
+++ b/src/providers/TerminalDashboardProvider.ts
@@ -14,6 +14,7 @@ import {
   TmuxDashboardWindowDto,
   NativeShellDto,
   AiToolConfig,
+  TerminalBackendType,
   resolveAiToolConfigs,
 } from "../types";
 
@@ -372,6 +373,15 @@ export class TerminalDashboardProvider
     return "tmux";
   }
 
+  private async ensureZellijSession(sessionId: string): Promise<void> {
+    if (
+      this.zellijSessionManager &&
+      typeof this.zellijSessionManager.switchSession === "function"
+    ) {
+      await this.zellijSessionManager.switchSession(sessionId);
+    }
+  }
+
   /**
    * Handles incoming messages from the webview and executes corresponding commands or actions.
    * @param message The message received from the webview
@@ -458,6 +468,7 @@ export class TerminalDashboardProvider
         let targetPaneId: string | undefined;
         try {
           if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+            await this.ensureZellijSession(message.sessionId);
             const panes = await this.zellijSessionManager?.listPanes();
             const activePane = panes?.find((pane) => pane.isFocused);
             targetPaneId = activePane?.id;
@@ -491,6 +502,7 @@ export class TerminalDashboardProvider
         {
           const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
           if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+            await this.ensureZellijSession(message.sessionId);
             await this.zellijSessionManager?.createTab({
               workingDirectory: workspacePath,
             });
@@ -512,6 +524,7 @@ export class TerminalDashboardProvider
         return;
       case "nextWindow":
         if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+          await this.ensureZellijSession(message.sessionId);
           await this.zellijSessionManager?.nextTab();
         } else {
           await this.tmuxSessionManager.nextWindow(message.sessionId);
@@ -520,6 +533,7 @@ export class TerminalDashboardProvider
         return;
       case "prevWindow":
         if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+          await this.ensureZellijSession(message.sessionId);
           await this.zellijSessionManager?.prevTab();
         } else {
           await this.tmuxSessionManager.prevWindow(message.sessionId);
@@ -528,6 +542,7 @@ export class TerminalDashboardProvider
         return;
       case "killWindow":
         if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+          await this.ensureZellijSession(message.sessionId);
           await this.zellijSessionManager?.killTab();
         } else {
           await this.tmuxSessionManager.killWindow(message.windowId);
@@ -539,6 +554,7 @@ export class TerminalDashboardProvider
           `[TerminalDashboard] selectWindow: sessionId=${message.sessionId}, windowId=${message.windowId}`,
         );
         if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+          await this.ensureZellijSession(message.sessionId);
           await this.zellijSessionManager?.selectTab(
             this.parseZellijTabIndex(message.windowId),
           );
@@ -549,6 +565,7 @@ export class TerminalDashboardProvider
         return;
       case "switchPane":
         if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+          await this.ensureZellijSession(message.sessionId);
           await this.zellijSessionManager?.selectPane(message.paneId);
         } else {
           await this.tmuxSessionManager.selectPane(
@@ -561,6 +578,7 @@ export class TerminalDashboardProvider
       case "splitPane":
         {
           if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+            await this.ensureZellijSession(message.sessionId);
             if (message.paneId) {
               await this.zellijSessionManager?.selectPane(message.paneId);
             }
@@ -589,6 +607,7 @@ export class TerminalDashboardProvider
       case "splitPaneWithCommand":
         {
           if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+            await this.ensureZellijSession(message.sessionId);
             if (message.paneId) {
               await this.zellijSessionManager?.selectPane(message.paneId);
             }
@@ -617,6 +636,7 @@ export class TerminalDashboardProvider
         return;
       case "killPane":
         if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+          await this.ensureZellijSession(message.sessionId);
           if (message.paneId) {
             await this.zellijSessionManager?.selectPane(message.paneId);
           }
@@ -628,6 +648,7 @@ export class TerminalDashboardProvider
         return;
       case "resizePane":
         if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
+          await this.ensureZellijSession(message.sessionId);
           const directionMap = {
             L: "left",
             R: "right",
@@ -781,7 +802,7 @@ export class TerminalDashboardProvider
         config.get("aiTools", []),
       );
 
-      await webview.postMessage({
+      const postResult = await webview.postMessage({
         type: "showAiToolSelector",
         sessionId,
         sessionName,
@@ -789,7 +810,9 @@ export class TerminalDashboardProvider
         tools,
         targetPaneId,
       } satisfies TmuxDashboardHostMessage);
-      return;
+      if (postResult !== false) {
+        return;
+      }
     }
 
     if (this.terminalProvider) {
@@ -818,11 +841,15 @@ export class TerminalDashboardProvider
     }
 
     try {
+      const sessionBackend = await this.getSessionBackend(sessionId);
+      const backendHint: TerminalBackendType =
+        sessionBackend === "zellij" ? "zellij" : "tmux";
       await this.terminalProvider.launchAiTool(
         sessionId,
         toolName,
         savePreference,
         targetPaneId,
+        backendHint,
       );
     } catch (error) {
       this.logger?.error(

--- a/src/providers/TerminalDashboardProvider.ts
+++ b/src/providers/TerminalDashboardProvider.ts
@@ -666,6 +666,7 @@ export class TerminalDashboardProvider
           message.sessionId,
           message.tool,
           message.savePreference,
+          message.targetPaneId,
         );
         await this.postSessionsToWebview();
         return;

--- a/src/providers/TerminalDashboardProvider.ts
+++ b/src/providers/TerminalDashboardProvider.ts
@@ -28,9 +28,6 @@ interface DashboardSessionSource {
   backend: DashboardBackend;
 }
 
-/**
- * Terminal Managers provider. Webview-based tmux session manager with inline pane controls (split, switch, resize, swap, kill). Filters sessions to current workspace.
- */
 export class TerminalDashboardProvider
   implements vscode.WebviewViewProvider, vscode.Disposable
 {
@@ -54,12 +51,6 @@ export class TerminalDashboardProvider
     private readonly zellijSessionManager?: ZellijSessionManager,
   ) {}
 
-  /**
-   * Resolves the webview view and sets up message handling and visibility changes.
-   * @param webviewView The webview view to resolve
-   * @param _context Webview view resolve context
-   * @param _token Cancellation token
-   */
   public resolveWebviewView(
     webviewView: vscode.WebviewView,
     _context: vscode.WebviewViewResolveContext,
@@ -133,9 +124,6 @@ export class TerminalDashboardProvider
     this.panel?.reveal();
   }
 
-  /**
-   * Discovers, filters, and posts tmux sessions and their panes to the webview.
-   */
   private async postSessionsToWebview(): Promise<void> {
     const webview = this.getActiveWebview();
     if (!webview) {
@@ -368,8 +356,6 @@ export class TerminalDashboardProvider
       }
     }
 
-    // Default to tmux (the tmuxSessionManager is always provided via constructor).
-    // If the session was not found in zellij, it is treated as a tmux session.
     return "tmux";
   }
 
@@ -382,10 +368,6 @@ export class TerminalDashboardProvider
     }
   }
 
-  /**
-   * Handles incoming messages from the webview and executes corresponding commands or actions.
-   * @param message The message received from the webview
-   */
   private async handleWebviewMessage(
     message: TmuxDashboardActionMessage | undefined,
   ): Promise<void> {
@@ -454,17 +436,15 @@ export class TerminalDashboardProvider
         if (this.instanceStore) {
           try {
             this.instanceStore.setActive(message.instanceId);
-            await vscode.commands.executeCommand(
-              "opencodeTui.switchNativeShell",
-            );
-          } catch {
-            // instance may not exist, refresh silently
+          await vscode.commands.executeCommand(
+            "opencodeTui.switchNativeShell",
+          );
+        } catch {
           }
         }
         await this.postSessionsToWebview();
         return;
       case "showAiToolSelector": {
-        // Get the active pane to use as the default target for AI tool launch
         let targetPaneId: string | undefined;
         try {
           if ((await this.getSessionBackend(message.sessionId)) === "zellij") {
@@ -747,11 +727,6 @@ export class TerminalDashboardProvider
     }
   }
 
-  /**
-   * Generates the HTML content for the webview by reading the external template.
-   * @param webview The webview to generate HTML for
-   * @returns The HTML string
-   */
   private getHtmlContent(webview: vscode.Webview): string {
     const scriptUri = webview
       .asWebviewUri(
@@ -784,11 +759,6 @@ export class TerminalDashboardProvider
       );
   }
 
-  /**
-   * Shows the AI tool selector in the webview after a new tmux session is created.
-   * @param sessionId The newly created session ID
-   * @param sessionName Display name for the session
-   */
   public async showAiToolSelector(
     sessionId: string,
     sessionName: string,
@@ -826,10 +796,6 @@ export class TerminalDashboardProvider
     }
   }
 
-  /**
-   * Handles AI tool selection from the webview.
-   * Launches the selected tool in the target pane of the tmux session.
-   */
   private async handleLaunchAiTool(
     sessionId: string,
     toolName: string,
@@ -858,11 +824,6 @@ export class TerminalDashboardProvider
     }
   }
 
-  /**
-   * Builds native shell DTOs from InstanceStore records that have no tmux session.
-   * @param workspacePath The current workspace path for filtering
-   * @returns Array of native shell DTOs
-   */
   private buildNativeShellDtos(workspacePath?: string): NativeShellDto[] {
     if (!this.instanceStore) {
       return [];
@@ -886,11 +847,7 @@ export class TerminalDashboardProvider
             ? vscode.Uri.parse(record.config.workspaceUri).fsPath
             : undefined;
 
-          if (recordWorkspace !== workspacePath) {
-            return false;
-          }
-
-          return true;
+          return recordWorkspace === workspacePath;
         })
         .map((record) => ({
           id: record.config.id,
@@ -903,10 +860,6 @@ export class TerminalDashboardProvider
     }
   }
 
-  /**
-   * Generates a random nonce for CSP.
-   * @returns A random 32-character string
-   */
   private getNonce(): string {
     let text = "";
     const possible =
@@ -917,9 +870,6 @@ export class TerminalDashboardProvider
     return text;
   }
 
-  /**
-   * Disposes of subscriptions and cleans up resources.
-   */
   public dispose(): void {
     this.stopPolling();
     this.disposeSubscriptions();

--- a/src/providers/TerminalProvider.test.ts
+++ b/src/providers/TerminalProvider.test.ts
@@ -1481,6 +1481,183 @@ describe("TerminalProvider", () => {
     });
   });
 
+  it("queues forced AI selector messages until the terminal webview resolves", () => {
+    mockConfiguration({ defaultAiTool: "opencode" });
+    const instanceStore = new InstanceStore();
+    instanceStore.upsert({
+      config: {
+        id: "workspace-pending-selector",
+        workspaceUri: "file:///workspaces/repo-pending-selector",
+        selectedAiTool: "codex",
+      },
+      runtime: {
+        terminalKey: "workspace-pending-selector",
+        tmuxSessionId: "tmux-pending-selector",
+      },
+      state: "connected",
+    });
+
+    provider = createProvider({ instanceStore });
+    const launchSpy = vi.spyOn(provider, "launchAiTool").mockResolvedValue();
+
+    provider.showAiToolSelector(
+      "repo-pending-selector",
+      "Repo Pending Selector",
+      true,
+      "%4",
+    );
+
+    expect(launchSpy).not.toHaveBeenCalled();
+
+    const { view } = resolveProvider(provider);
+
+    expect(view.webview.postMessage).toHaveBeenCalledWith({
+      type: "showAiToolSelector",
+      sessionId: "tmux-pending-selector",
+      sessionName: "Repo Pending Selector",
+      defaultTool: undefined,
+      tools: DEFAULT_AI_TOOLS,
+      targetPaneId: "%4",
+    });
+  });
+
+  it("requeues AI selector messages when postMessage reports the webview hidden", async () => {
+    mockConfiguration({ defaultAiTool: "opencode" });
+    const instanceStore = new InstanceStore();
+    instanceStore.upsert({
+      config: {
+        id: "workspace-hidden-selector",
+        workspaceUri: "file:///workspaces/repo-hidden-selector",
+        selectedAiTool: "codex",
+      },
+      runtime: {
+        terminalKey: "workspace-hidden-selector",
+        tmuxSessionId: "tmux-hidden-selector",
+      },
+      state: "connected",
+    });
+
+    provider = createProvider({ instanceStore });
+    const launchSpy = vi.spyOn(provider, "launchAiTool").mockResolvedValue();
+    const { view } = resolveProvider(provider);
+    const selectorMessage = {
+      type: "showAiToolSelector",
+      sessionId: "tmux-hidden-selector",
+      sessionName: "Repo Hidden Selector",
+      defaultTool: undefined,
+      tools: DEFAULT_AI_TOOLS,
+      targetPaneId: "%5",
+    };
+    vi.mocked(view.webview.postMessage).mockClear();
+    vi.mocked(view.webview.postMessage)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(true);
+
+    provider.showAiToolSelector(
+      "repo-hidden-selector",
+      "Repo Hidden Selector",
+      true,
+      "%5",
+    );
+
+    expect(launchSpy).not.toHaveBeenCalled();
+    expect(view.webview.postMessage).toHaveBeenCalledWith(selectorMessage);
+
+    const visibilityListener = vi.mocked(view.onDidChangeVisibility).mock
+      .calls[0]?.[0] as (() => void) | undefined;
+    expect(visibilityListener).toBeDefined();
+    view.visible = true;
+    visibilityListener?.();
+    await Promise.resolve();
+
+    expect(view.webview.postMessage).toHaveBeenCalledTimes(2);
+    expect(view.webview.postMessage).toHaveBeenLastCalledWith(selectorMessage);
+  });
+
+  it("routes AI tool launches to tmux when an instance is tmux mapped", async () => {
+    mockConfiguration();
+    const instanceStore = new InstanceStore();
+    instanceStore.upsert({
+      config: {
+        id: "workspace-tmux-launch-route",
+        workspaceUri: "file:///workspaces/repo-tmux-launch-route",
+      },
+      runtime: {
+        terminalKey: "workspace-tmux-launch-route",
+        tmuxSessionId: "tmux-session-x",
+      },
+      state: "connected",
+    });
+    const listPanes = vi
+      .fn()
+      .mockResolvedValue([{ paneId: "%42", isActive: true }]);
+    const sendTextToPane = vi.fn().mockResolvedValue(undefined);
+    const tmuxSessionManager = {
+      listPanes,
+      sendTextToPane,
+    } as unknown as TmuxSessionManager;
+    const zellijSessionManager = {
+      switchSession: vi.fn(),
+      selectPane: vi.fn(),
+      sendTextToPane: vi.fn(),
+    } as any;
+
+    provider = createProvider({
+      instanceStore,
+      tmuxSessionManager,
+      zellijSessionManager,
+    });
+
+    await provider.launchAiTool("tmux-session-x", "codex", false, "%42");
+
+    expect(sendTextToPane).toHaveBeenCalledWith("%42", "codex");
+    expect(zellijSessionManager.switchSession).not.toHaveBeenCalled();
+    expect(zellijSessionManager.selectPane).not.toHaveBeenCalled();
+    expect(zellijSessionManager.sendTextToPane).not.toHaveBeenCalled();
+  });
+
+  it("switches to the target zellij session before launching into a pane", async () => {
+    mockConfiguration();
+    const instanceStore = new InstanceStore();
+    instanceStore.upsert({
+      config: {
+        id: "workspace-zellij-launch-route",
+        workspaceUri: "file:///workspaces/repo-zellij-launch-route",
+      },
+      runtime: {
+        terminalKey: "workspace-zellij-launch-route",
+        zellijSessionId: "zellij-target",
+      },
+      state: "connected",
+    });
+    const switchSession = vi.fn().mockResolvedValue(undefined);
+    const selectPane = vi.fn().mockResolvedValue(undefined);
+    const sendTextToPane = vi.fn().mockResolvedValue(undefined);
+    const zellijSessionManager = {
+      isAvailable: vi.fn().mockResolvedValue(true),
+      switchSession,
+      selectPane,
+      sendTextToPane,
+    } as any;
+
+    provider = createProvider({ instanceStore, zellijSessionManager });
+    vi.spyOn((provider as any).sessionRuntime, "getActiveBackend").mockReturnValue("zellij");
+
+    await provider.launchAiTool("zellij-target", "opencode", false, "pane-7");
+
+    expect(switchSession).toHaveBeenCalledWith("zellij-target");
+    expect(selectPane).toHaveBeenCalledWith("pane-7");
+    expect(sendTextToPane).toHaveBeenCalledWith("opencode -c", {
+      submit: true,
+    });
+    expect(switchSession.mock.invocationCallOrder[0]).toBeLessThan(
+      selectPane.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+    expect(switchSession.mock.invocationCallOrder[0]).toBeLessThan(
+      sendTextToPane.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+  });
+
   it("launches AI tools against the normalized tmux session and active pane", async () => {
     const configuration = mockConfiguration();
     const instanceStore = new InstanceStore();

--- a/src/providers/TerminalProvider.test.ts
+++ b/src/providers/TerminalProvider.test.ts
@@ -67,6 +67,7 @@ describe("TerminalProvider", () => {
     defaultAiTool?: string;
     aiTools?: readonly unknown[];
     collapseSecondaryBarOnEditorOpen?: boolean;
+    promptAiToolOnSession?: boolean;
   }) {
     const {
       autoStartOnOpen = false,
@@ -74,6 +75,7 @@ describe("TerminalProvider", () => {
       defaultAiTool = "opencode",
       aiTools = DEFAULT_AI_TOOLS,
       collapseSecondaryBarOnEditorOpen = false,
+      promptAiToolOnSession = true,
     } = options ?? {};
 
     const configuration = {
@@ -98,6 +100,9 @@ describe("TerminalProvider", () => {
         }
         if (key === "collapseSecondaryBarOnEditorOpen") {
           return collapseSecondaryBarOnEditorOpen;
+        }
+        if (key === "promptAiToolOnSession") {
+          return promptAiToolOnSession;
         }
         return defaultValue;
       }),
@@ -1481,6 +1486,22 @@ describe("TerminalProvider", () => {
     });
   });
 
+  it("returns early without showing selector when forceShow and promptAiToolOnSession is disabled", () => {
+    mockConfiguration({ promptAiToolOnSession: false });
+    provider = createProvider();
+    const { view } = resolveProvider(provider);
+
+    vi.mocked(view.webview.postMessage).mockClear();
+
+    provider.showAiToolSelector("session-disabled", "Session Disabled", true);
+
+    expect(view.webview.postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "showAiToolSelector",
+      }),
+    );
+  });
+
   it("queues forced AI selector messages until the terminal webview resolves", () => {
     mockConfiguration({ defaultAiTool: "opencode" });
     const instanceStore = new InstanceStore();
@@ -1549,9 +1570,7 @@ describe("TerminalProvider", () => {
       targetPaneId: "%5",
     };
     vi.mocked(view.webview.postMessage).mockClear();
-    vi.mocked(view.webview.postMessage)
-      .mockResolvedValueOnce(false)
-      .mockResolvedValue(true);
+    vi.mocked(view.webview.postMessage).mockReturnValue(false);
 
     provider.showAiToolSelector(
       "repo-hidden-selector",
@@ -1572,6 +1591,260 @@ describe("TerminalProvider", () => {
 
     expect(view.webview.postMessage).toHaveBeenCalledTimes(2);
     expect(view.webview.postMessage).toHaveBeenLastCalledWith(selectorMessage);
+  });
+
+  it("requeues message when postMessage Thenable resolves to false", async () => {
+    mockConfiguration({ defaultAiTool: "opencode" });
+    const instanceStore = new InstanceStore();
+    instanceStore.upsert({
+      config: {
+        id: "workspace-thenable-selector",
+        workspaceUri: "file:///workspaces/repo-thenable-selector",
+        selectedAiTool: "codex",
+      },
+      runtime: {
+        terminalKey: "workspace-thenable-selector",
+        tmuxSessionId: "tmux-thenable-selector",
+      },
+      state: "connected",
+    });
+
+    provider = createProvider({ instanceStore });
+    const { view } = resolveProvider(provider);
+    view.visible = true;
+    const selectorMessage = {
+      type: "showAiToolSelector",
+      sessionId: "tmux-thenable-selector",
+      sessionName: "Repo Thenable Selector",
+      defaultTool: undefined,
+      tools: DEFAULT_AI_TOOLS,
+      targetPaneId: "%6",
+    };
+    vi.mocked(view.webview.postMessage).mockClear();
+    vi.mocked(view.webview.postMessage).mockResolvedValue(false);
+
+    provider.showAiToolSelector(
+      "repo-thenable-selector",
+      "Repo Thenable Selector",
+      true,
+      "%6",
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(view.webview.postMessage).toHaveBeenCalledWith(selectorMessage);
+    expect(provider["pendingWebviewMessages"]).toContainEqual(selectorMessage);
+  });
+
+  it("requeues Thenable selector messages without flushing when the webview is hidden", async () => {
+    mockConfiguration({ defaultAiTool: "opencode" });
+    const instanceStore = new InstanceStore();
+    instanceStore.upsert({
+      config: {
+        id: "workspace-thenable-hidden",
+        workspaceUri: "file:///workspaces/repo-thenable-hidden",
+        selectedAiTool: "codex",
+      },
+      runtime: {
+        terminalKey: "workspace-thenable-hidden",
+        tmuxSessionId: "tmux-thenable-hidden",
+      },
+      state: "connected",
+    });
+
+    provider = createProvider({ instanceStore });
+    const { view } = resolveProvider(provider);
+    view.visible = false;
+    const selectorMessage = {
+      type: "showAiToolSelector",
+      sessionId: "tmux-thenable-hidden",
+      sessionName: "Repo Thenable Hidden",
+      defaultTool: undefined,
+      tools: DEFAULT_AI_TOOLS,
+      targetPaneId: "%7",
+    };
+    vi.mocked(view.webview.postMessage).mockClear();
+    vi.mocked(view.webview.postMessage).mockReturnValue({
+      then: (resolve: (value: boolean) => void) => {
+        resolve(false);
+        return Promise.resolve(false);
+      },
+    } as Thenable<boolean>);
+
+    provider.showAiToolSelector(
+      "repo-thenable-hidden",
+      "Repo Thenable Hidden",
+      true,
+      "%7",
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(view.webview.postMessage).toHaveBeenCalledWith(selectorMessage);
+    expect(provider["pendingWebviewMessages"]).toContainEqual(selectorMessage);
+  });
+
+  it("flushes queued selector messages again when a boolean postMessage reports false", () => {
+    mockConfiguration({ defaultAiTool: "opencode" });
+    const instanceStore = new InstanceStore();
+    instanceStore.upsert({
+      config: {
+        id: "workspace-boolean-flush",
+        workspaceUri: "file:///workspaces/repo-boolean-flush",
+        selectedAiTool: "codex",
+      },
+      runtime: {
+        terminalKey: "workspace-boolean-flush",
+        tmuxSessionId: "tmux-boolean-flush",
+      },
+      state: "connected",
+    });
+
+    provider = createProvider({ instanceStore });
+    const { view } = resolveProvider(provider);
+    const selectorMessage: any = {
+      type: "showAiToolSelector",
+      sessionId: "tmux-boolean-flush",
+      sessionName: "Repo Boolean Flush",
+      defaultTool: undefined,
+      tools: DEFAULT_AI_TOOLS,
+      targetPaneId: "%8",
+    };
+    vi.mocked(view.webview.postMessage).mockClear();
+    vi.mocked(view.webview.postMessage).mockReturnValue(false);
+
+    provider["pendingWebviewMessages"].push(selectorMessage);
+    view.visible = true;
+
+    (provider as any).flushPendingWebviewMessages(view.webview);
+
+    expect(view.webview.postMessage).toHaveBeenCalledWith(selectorMessage);
+    expect(provider["pendingWebviewMessages"]).toContainEqual(selectorMessage);
+  });
+
+  it("queues selector messages when no webview is attached", () => {
+    mockConfiguration({ defaultAiTool: "opencode" });
+    provider = createProvider();
+
+    (provider as any).postWebviewMessage({
+      type: "showAiToolSelector",
+      sessionId: "session-no-webview",
+      sessionName: "No Webview",
+      defaultTool: undefined,
+      tools: DEFAULT_AI_TOOLS,
+      targetPaneId: undefined,
+    });
+
+    expect(provider["pendingWebviewMessages"]).toContainEqual({
+      type: "showAiToolSelector",
+      sessionId: "session-no-webview",
+      sessionName: "No Webview",
+      defaultTool: undefined,
+      tools: DEFAULT_AI_TOOLS,
+      targetPaneId: undefined,
+    });
+  });
+
+  it("ignores non-selector messages when a boolean postMessage reports false", () => {
+    mockConfiguration();
+    provider = createProvider();
+    const { view } = resolveProvider(provider);
+    vi.mocked(view.webview.postMessage).mockReturnValue(false);
+
+    (provider as any).postWebviewMessage({ type: "output", text: "hello" });
+
+    expect(provider["pendingWebviewMessages"]).toHaveLength(0);
+  });
+
+  it("ignores non-selector messages when no webview is attached", () => {
+    mockConfiguration();
+    provider = createProvider();
+
+    (provider as any).postWebviewMessage({ type: "output", text: "hello" });
+
+    expect(provider["pendingWebviewMessages"]).toHaveLength(0);
+  });
+
+  it("ignores non-selector Thenable messages when the webview is hidden", () => {
+    mockConfiguration();
+    provider = createProvider();
+    const { view } = resolveProvider(provider);
+    view.visible = false;
+    vi.mocked(view.webview.postMessage).mockReturnValue({
+      then: (resolve: (value: boolean) => void) => {
+        resolve(false);
+        return Promise.resolve(false);
+      },
+    } as any);
+
+    (provider as any).postWebviewMessage({ type: "output", text: "hello" });
+
+    expect(provider["pendingWebviewMessages"]).toHaveLength(0);
+  });
+
+  it("ignores non-selector messages when flushing a false postMessage result", () => {
+    mockConfiguration();
+    provider = createProvider();
+    const { view } = resolveProvider(provider);
+    vi.mocked(view.webview.postMessage).mockReturnValue(false);
+
+    provider["pendingWebviewMessages"].push({ type: "output", text: "hello" } as any);
+    (provider as any).flushPendingWebviewMessages(view.webview);
+
+    expect(provider["pendingWebviewMessages"]).toHaveLength(0);
+  });
+
+  it("requeues selector messages again when flush sees a Thenable false result", () => {
+    mockConfiguration();
+    provider = createProvider();
+    const { view } = resolveProvider(provider);
+    const selectorMessage = {
+      type: "showAiToolSelector",
+      sessionId: "tmux-flush-thenable",
+      sessionName: "Flush Thenable",
+      defaultTool: undefined,
+      tools: DEFAULT_AI_TOOLS,
+      targetPaneId: "%10",
+    };
+    provider["pendingWebviewMessages"].push(selectorMessage as any);
+    vi.mocked(view.webview.postMessage).mockReturnValue({
+      then: (resolve: (value: boolean) => void) => {
+        resolve(false);
+        return Promise.resolve(false);
+      },
+    } as any);
+
+    (provider as any).flushPendingWebviewMessages(view.webview);
+
+    expect(provider["pendingWebviewMessages"]).toContainEqual(selectorMessage);
+  });
+
+  it("does not requeue selector messages when flush sees a Thenable true result", () => {
+    mockConfiguration();
+    provider = createProvider();
+    const { view } = resolveProvider(provider);
+    const selectorMessage = {
+      type: "showAiToolSelector",
+      sessionId: "tmux-flush-thenable-true",
+      sessionName: "Flush Thenable True",
+      defaultTool: undefined,
+      tools: DEFAULT_AI_TOOLS,
+      targetPaneId: "%11",
+    };
+    provider["pendingWebviewMessages"].push(selectorMessage as any);
+    vi.mocked(view.webview.postMessage).mockReturnValue({
+      then: (resolve: (value: boolean) => void) => {
+        resolve(true);
+        return Promise.resolve(true);
+      },
+    } as any);
+
+    (provider as any).flushPendingWebviewMessages(view.webview);
+
+    expect(provider["pendingWebviewMessages"]).toHaveLength(0);
   });
 
   it("routes AI tool launches to tmux when an instance is tmux mapped", async () => {
@@ -1824,6 +2097,24 @@ describe("TerminalProvider", () => {
 
     expect(zellijSelectPane).toHaveBeenCalledWith("terminal_5");
     expect(zellijSendTextToPane).toHaveBeenCalledWith("codex", { submit: true });
+  });
+
+  it("honors the explicit backendHint when launching an AI tool", async () => {
+    mockConfiguration();
+    provider = createProvider();
+    const warnSpy = vi.spyOn((provider as any).logger, "warn");
+
+    await provider.launchAiTool(
+      "session-backend-hint",
+      "codex",
+      false,
+      undefined,
+      "native",
+    );
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("backend native does not support pane targeting"),
+    );
   });
 
   it("executeRawTmuxCommand rejects when active backend is not tmux", async () => {

--- a/src/providers/TerminalProvider.ts
+++ b/src/providers/TerminalProvider.ts
@@ -817,6 +817,10 @@ export class TerminalProvider
         "sendKeybindingsToShell",
         true,
       ),
+      showTmuxWindowControls: config.get<boolean>(
+        "showTmuxWindowControls",
+        true,
+      ),
     };
   }
 
@@ -846,6 +850,7 @@ export class TerminalProvider
       cursorStyle: terminalConfig.cursorStyle,
       scrollback: String(terminalConfig.scrollback),
       sendKeybindingsToShell: String(terminalConfig.sendKeybindingsToShell),
+      showTmuxWindowControls: String(terminalConfig.showTmuxWindowControls),
     });
   }
 

--- a/src/providers/TerminalProvider.ts
+++ b/src/providers/TerminalProvider.ts
@@ -454,6 +454,7 @@ export class TerminalProvider
     toolName: string,
     savePreference: boolean,
     targetPaneId?: string,
+    backendHint?: TerminalBackendType,
   ): Promise<void> {
     if (savePreference) {
       const config = vscode.workspace.getConfiguration("opencodeTui");
@@ -477,11 +478,13 @@ export class TerminalProvider
     const launchCommand = operator.getLaunchCommand(tool);
     const instance = this.instanceStore?.get(instanceId);
     const activeBackend = this.sessionRuntime.getActiveBackend();
-    const effectiveBackend: TerminalBackendType = instance?.runtime.tmuxSessionId
-      ? "tmux"
-      : instance?.runtime.zellijSessionId
-        ? "zellij"
-        : activeBackend;
+    const effectiveBackend: TerminalBackendType = backendHint
+      ? backendHint
+      : instance?.runtime.tmuxSessionId
+        ? "tmux"
+        : instance?.runtime.zellijSessionId
+          ? "zellij"
+          : activeBackend;
 
     try {
       if (effectiveBackend === "zellij") {
@@ -793,7 +796,18 @@ export class TerminalProvider
   private flushPendingWebviewMessages(webview: vscode.Webview): void {
     const messages = this.pendingWebviewMessages.splice(0);
     for (const message of messages) {
-      webview.postMessage(message);
+      const postResult = webview.postMessage(message) as
+        | boolean
+        | Thenable<boolean>;
+      if (this.isThenablePostResult(postResult)) {
+        void postResult.then((delivered) => {
+          if (!delivered && this.isQueueableHostMessage(message)) {
+            this.replacePendingWebviewMessage(message);
+          }
+        });
+      } else if (!postResult && this.isQueueableHostMessage(message)) {
+        this.replacePendingWebviewMessage(message);
+      }
     }
   }
 

--- a/src/providers/TerminalProvider.ts
+++ b/src/providers/TerminalProvider.ts
@@ -37,6 +37,8 @@ export class TerminalProvider
   private readonly aiToolRegistry: AiToolOperatorRegistry;
   private readonly sessionRuntime: SessionRuntime;
   private readonly messageRouter: MessageRouter;
+  private readonly pendingWebviewMessages: HostMessage[] = [];
+  private pendingQueueablePostChecks = 0;
 
   public constructor(
     private readonly context: vscode.ExtensionContext,
@@ -196,9 +198,39 @@ export class TerminalProvider
 
     this.postTerminalConfig();
     this.postCurrentSessionState(webviewView.webview);
+    this.flushPendingWebviewMessages(webviewView.webview);
 
     const config = vscode.workspace.getConfiguration("opencodeTui");
     const autoStartOnOpen = config.get<boolean>("autoStartOnOpen", true);
+    const visibilityListener = webviewView.onDidChangeVisibility(() => {
+      if (!webviewView.visible) {
+        return;
+      }
+
+      const hadPendingMessages =
+        this.pendingWebviewMessages.length > 0 ||
+        this.pendingQueueablePostChecks > 0;
+      this.flushPendingWebviewMessages(webviewView.webview);
+      if (!hadPendingMessages) {
+        this.postWebviewMessage({ type: "webviewVisible" });
+        this.postTerminalConfig();
+      }
+
+      if (autoStartOnOpen && !this.isStarted()) {
+        if (this.getNativeRestoreRecord()) {
+          void this.promptNativeRestore().then((restored) => {
+            if (!restored) {
+              void this.startOpenCode();
+            }
+          });
+        } else {
+          void this.startOpenCode();
+        }
+        visibilityListener.dispose();
+      }
+    });
+    webviewView.onDidDispose(() => visibilityListener.dispose());
+
     if (autoStartOnOpen) {
       if (webviewView.visible) {
         if (!this.isStarted()) {
@@ -212,27 +244,6 @@ export class TerminalProvider
             void this.startOpenCode();
           }
         }
-      } else {
-        const visibilityListener = webviewView.onDidChangeVisibility(() => {
-          if (webviewView.visible) {
-            this.postWebviewMessage({ type: "webviewVisible" });
-            this.postTerminalConfig();
-            if (!this.isStarted()) {
-              if (this.getNativeRestoreRecord()) {
-                void this.promptNativeRestore().then((restored) => {
-                  if (!restored) {
-                    void this.startOpenCode();
-                  }
-                });
-              } else {
-                void this.startOpenCode();
-              }
-              visibilityListener.dispose();
-            }
-          }
-        });
-
-        webviewView.onDidDispose(() => visibilityListener.dispose());
       }
     } else if (webviewView.visible && !this.isStarted()) {
       void this.promptNativeRestore();
@@ -464,15 +475,27 @@ export class TerminalProvider
 
     const operator = this.aiToolRegistry.getForConfig(tool);
     const launchCommand = operator.getLaunchCommand(tool);
+    const instance = this.instanceStore?.get(instanceId);
     const activeBackend = this.sessionRuntime.getActiveBackend();
+    const effectiveBackend: TerminalBackendType = instance?.runtime.tmuxSessionId
+      ? "tmux"
+      : instance?.runtime.zellijSessionId
+        ? "zellij"
+        : activeBackend;
 
     try {
-      if (activeBackend === "zellij") {
+      if (effectiveBackend === "zellij") {
         if (!this.zellijSessionManager) {
           this.logger.warn(
             "[TerminalProvider] launchAiTool skipped: zellij manager unavailable",
           );
           return;
+        }
+        const effectiveZellijSessionId =
+          this.sessionRuntime.resolveZellijSessionIdForInstance(instanceId) ??
+          sessionId;
+        if (typeof this.zellijSessionManager.switchSession === "function") {
+          await this.zellijSessionManager.switchSession(effectiveZellijSessionId);
         }
         if (targetPaneId) {
           await this.zellijSessionManager.selectPane(targetPaneId);
@@ -483,9 +506,9 @@ export class TerminalProvider
         return;
       }
 
-      if (activeBackend !== "tmux" || !this.tmuxSessionManager) {
+      if (effectiveBackend !== "tmux" || !this.tmuxSessionManager) {
         this.logger.warn(
-          `[TerminalProvider] launchAiTool skipped: backend ${activeBackend} does not support pane targeting`,
+          `[TerminalProvider] launchAiTool skipped: backend ${effectiveBackend} does not support pane targeting`,
         );
         return;
       }
@@ -698,7 +721,80 @@ export class TerminalProvider
 
   private postWebviewMessage(message: unknown): void {
     const webview = this._panel?.webview ?? this._view?.webview;
-    webview?.postMessage(message);
+    if (webview) {
+      const postResult = webview.postMessage(message) as
+        | boolean
+        | Thenable<boolean>;
+      if (this.isThenablePostResult(postResult)) {
+        if (this.isQueueableHostMessage(message)) {
+          this.pendingQueueablePostChecks += 1;
+        }
+        void postResult.then((delivered) => {
+          if (this.isQueueableHostMessage(message)) {
+            this.pendingQueueablePostChecks = Math.max(
+              0,
+              this.pendingQueueablePostChecks - 1,
+            );
+          }
+          if (!delivered && this.isQueueableHostMessage(message)) {
+            this.replacePendingWebviewMessage(message);
+            if (this.isWebviewVisible()) {
+              this.flushPendingWebviewMessages(webview);
+            }
+          }
+        });
+        return;
+      }
+
+      if (!postResult && this.isQueueableHostMessage(message)) {
+        this.replacePendingWebviewMessage(message);
+      }
+      return;
+    }
+
+    if (this.isQueueableHostMessage(message)) {
+      this.replacePendingWebviewMessage(message);
+    }
+  }
+
+  private isWebviewVisible(): boolean {
+    return this._panel?.visible === true || this._view?.visible === true;
+  }
+
+  private isThenablePostResult(
+    value: boolean | Thenable<boolean>,
+  ): value is Thenable<boolean> {
+    return typeof value === "object" && value !== null && "then" in value;
+  }
+
+  private isQueueableHostMessage(
+    message: unknown,
+  ): message is Extract<HostMessage, { type: "showAiToolSelector" }> {
+    return (
+      typeof message === "object" &&
+      message !== null &&
+      "type" in message &&
+      message.type === "showAiToolSelector"
+    );
+  }
+
+  private replacePendingWebviewMessage(message: HostMessage): void {
+    const existingIndex = this.pendingWebviewMessages.findIndex(
+      (pendingMessage) => pendingMessage.type === message.type,
+    );
+    if (existingIndex >= 0) {
+      this.pendingWebviewMessages.splice(existingIndex, 1, message);
+      return;
+    }
+
+    this.pendingWebviewMessages.push(message);
+  }
+
+  private flushPendingWebviewMessages(webview: vscode.Webview): void {
+    const messages = this.pendingWebviewMessages.splice(0);
+    for (const message of messages) {
+      webview.postMessage(message);
+    }
   }
 
   private postCurrentSessionState(webview: vscode.Webview): void {
@@ -763,6 +859,7 @@ export class TerminalProvider
 
     this.postTerminalConfig();
     this.postCurrentSessionState(panel.webview);
+    this.flushPendingWebviewMessages(panel.webview);
 
     panel.onDidDispose(() => {
       if (this._panel === panel) {

--- a/src/providers/TerminalProvider.ts
+++ b/src/providers/TerminalProvider.ts
@@ -895,7 +895,6 @@ export class TerminalProvider
         "workbench.view.extension.opencodeTuiContainer",
       );
     } catch {
-      // Best-effort reveal; fall through to showing the specific view when available.
     }
 
     this._view?.show?.(true);

--- a/src/providers/TerminalProvider.ts
+++ b/src/providers/TerminalProvider.ts
@@ -609,6 +609,9 @@ export class TerminalProvider
     targetPaneId?: string,
   ): void {
     const config = vscode.workspace.getConfiguration("opencodeTui");
+    if (forceShow && !config.get<boolean>("promptAiToolOnSession", true)) {
+      return;
+    }
     const instanceId =
       this.sessionRuntime.resolveInstanceIdFromSessionId(sessionId);
     const effectiveSessionId =

--- a/src/terminals/TerminalManager.test.ts
+++ b/src/terminals/TerminalManager.test.ts
@@ -505,6 +505,75 @@ describe("TerminalManager", () => {
       );
     });
 
+    it("should detect pwsh from a Unix-style path and use -NoExit -Command args on Windows", () => {
+      Object.defineProperty(process, "platform", {
+        value: "win32",
+      });
+
+      const originalIncludes = String.prototype.includes;
+      const originalEndsWith = String.prototype.endsWith;
+      const includesSpy = vi
+        .spyOn(String.prototype, "includes")
+        .mockImplementation(function (this: string, searchString: string) {
+          if (searchString === "powershell" || searchString === "pwsh") {
+            return false;
+          }
+          return originalIncludes.call(this, searchString);
+        });
+      const endsWithSpy = vi
+        .spyOn(String.prototype, "endsWith")
+        .mockImplementation(function (this: string, searchString: string) {
+          if (searchString === "pwsh.exe") {
+            return true;
+          }
+          return originalEndsWith.call(this, searchString);
+        });
+
+      try {
+        vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+          get: vi.fn((key: string) => {
+            if (key === "shellPath") return "/usr/bin/pwsh";
+            if (key === "shellArgs") return [];
+            return undefined;
+          }),
+          update: vi.fn(),
+        } as any);
+
+        manager.createTerminal("pwsh-terminal", "opencode");
+
+        expect(nodePty.spawn).toHaveBeenCalledWith(
+          "/usr/bin/pwsh",
+          ["-NoExit", "-Command", "opencode"],
+          expect.any(Object),
+        );
+      } finally {
+        includesSpy.mockRestore();
+        endsWithSpy.mockRestore();
+      }
+    });
+
+    it("should fall back to -c for non-PowerShell Windows shells", () => {
+      Object.defineProperty(process, "platform", {
+        value: "win32",
+      });
+      vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+        get: vi.fn((key: string) => {
+          if (key === "shellPath") return "C:\\Tools\\bash.exe";
+          if (key === "shellArgs") return [];
+          return undefined;
+        }),
+        update: vi.fn(),
+      } as any);
+
+      manager.createTerminal("bash-terminal", "opencode");
+
+      expect(nodePty.spawn).toHaveBeenCalledWith(
+        "C:\\Tools\\bash.exe",
+        ["-c", "opencode"],
+        expect.any(Object),
+      );
+    });
+
     it("should fall back to COMSPEC on Windows when VS Code shell is empty", () => {
       Object.defineProperty(process, "platform", {
         value: "win32",

--- a/src/test/e2e/suite/ai-tool-selector.e2e.ts
+++ b/src/test/e2e/suite/ai-tool-selector.e2e.ts
@@ -1,0 +1,131 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+
+interface ConfigurationProperty {
+  type?: string;
+  default?: unknown;
+  enum?: string[];
+  items?: {
+    type?: string;
+    properties?: Record<string, ConfigurationProperty>;
+  };
+}
+
+interface AiToolDefault {
+  name: string;
+  label: string;
+  path: string;
+  args: string[];
+  aliases?: string[];
+  operator: string;
+}
+
+async function activateExtension(): Promise<vscode.Extension<unknown>> {
+  const extension = vscode.extensions.getExtension(
+    "islee23520.opencode-sidebar-tui",
+  );
+
+  assert.ok(extension, "Extension should be available in the test host");
+  await extension.activate();
+  return extension;
+}
+
+function getConfigurationProperties(
+  extension: vscode.Extension<unknown>,
+): Record<string, ConfigurationProperty> {
+  const packageJSON = extension.packageJSON as {
+    contributes?: {
+      configuration?: {
+        properties?: Record<string, ConfigurationProperty>;
+      };
+    };
+  };
+
+  const properties = packageJSON.contributes?.configuration?.properties;
+  assert.ok(properties, "Extension should contribute configuration properties");
+  return properties;
+}
+
+suite("AI tool selector E2E surface", () => {
+  test("contributes promptAiToolOnSession with expected type and default", async () => {
+    const extension = await activateExtension();
+    const properties = getConfigurationProperties(extension);
+    const promptAiToolOnSession = properties["opencodeTui.promptAiToolOnSession"];
+
+    assert.strictEqual(promptAiToolOnSession?.type, "boolean");
+    assert.strictEqual(promptAiToolOnSession?.default, true);
+  });
+
+  test("contributes defaultAiTool as opencode", async () => {
+    const extension = await activateExtension();
+    const properties = getConfigurationProperties(extension);
+    const defaultAiTool = properties["opencodeTui.defaultAiTool"];
+
+    assert.strictEqual(defaultAiTool?.type, "string");
+    assert.strictEqual(defaultAiTool?.default, "opencode");
+  });
+
+  test("defines the default AI tool selector entries", async () => {
+    const extension = await activateExtension();
+    const properties = getConfigurationProperties(extension);
+    const aiTools = properties["opencodeTui.aiTools"];
+    const defaults = aiTools?.default as AiToolDefault[] | undefined;
+
+    assert.strictEqual(aiTools?.type, "array");
+    assert.ok(Array.isArray(defaults), "aiTools default should be an array");
+    assert.strictEqual(defaults.length, 3);
+    assert.deepStrictEqual(
+      defaults.map(({ name }) => name),
+      ["opencode", "claude", "codex"],
+    );
+
+    for (const tool of defaults) {
+      assert.strictEqual(typeof tool.name, "string");
+      assert.strictEqual(typeof tool.label, "string");
+      assert.strictEqual(typeof tool.path, "string");
+      assert.ok(Array.isArray(tool.args), `${tool.name} args should be array`);
+      assert.strictEqual(typeof tool.operator, "string");
+    }
+
+    const claude = defaults.find(({ name }) => name === "claude");
+    assert.deepStrictEqual(claude?.aliases, ["claude"]);
+  });
+
+  test("defines AI tool item schema required by the selector", async () => {
+    const extension = await activateExtension();
+    const properties = getConfigurationProperties(extension);
+    const itemProperties = properties["opencodeTui.aiTools"]?.items?.properties;
+
+    assert.strictEqual(itemProperties?.name?.type, "string");
+    assert.strictEqual(itemProperties?.label?.type, "string");
+    assert.strictEqual(itemProperties?.path?.type, "string");
+    assert.strictEqual(itemProperties?.args?.type, "array");
+    assert.strictEqual(itemProperties?.aliases?.type, "array");
+    assert.strictEqual(itemProperties?.operator?.type, "string");
+  });
+
+  test("supports available terminal backends for selector launch flows", async () => {
+    const extension = await activateExtension();
+    const properties = getConfigurationProperties(extension);
+    const terminalBackend = properties["opencodeTui.terminalBackend"];
+
+    assert.strictEqual(terminalBackend?.type, "string");
+    assert.deepStrictEqual(terminalBackend?.enum, ["native", "tmux", "zellij"]);
+  });
+
+  test("registers selector-triggering and dashboard commands", async () => {
+    await activateExtension();
+    const commands = await vscode.commands.getCommands(true);
+    const expectedCommands = [
+      "opencodeTui.switchTmuxSession",
+      "opencodeTui.browseTmuxSessions",
+      "opencodeTui.switchNativeShell",
+      "opencodeTui.toggleDashboard",
+      "opencodeTui.openDashboardInEditor",
+    ];
+
+    for (const command of expectedCommands) {
+      assert.ok(commands.includes(command), `${command} should be registered`);
+    }
+  });
+});

--- a/src/test/e2e/suite/command-behavior.e2e.ts
+++ b/src/test/e2e/suite/command-behavior.e2e.ts
@@ -1,0 +1,50 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+
+async function activateExtension(): Promise<vscode.Extension<unknown>> {
+  const extension = vscode.extensions.getExtension(
+    "islee23520.opencode-sidebar-tui",
+  );
+
+  assert.ok(extension, "Extension should be available in the test host");
+  await extension.activate();
+  return extension;
+}
+
+async function executeCommandWithoutUserInput(commandId: string): Promise<void> {
+  const closeQuickPick =
+    commandId === "opencodeTui.browseTmuxSessions"
+      ? setTimeout(() => {
+          void vscode.commands.executeCommand("workbench.action.closeQuickOpen");
+        }, 250)
+      : undefined;
+
+  try {
+    await vscode.commands.executeCommand(commandId);
+  } finally {
+    if (closeQuickPick) {
+      clearTimeout(closeQuickPick);
+    }
+  }
+}
+
+suite("Command behavior", () => {
+  const safeCommands = [
+    "opencodeTui.start",
+    "opencodeTui.toggleDashboard",
+    "opencodeTui.openTerminalManager",
+    "opencodeTui.browseTmuxSessions",
+    "opencodeTui.switchTmuxSession",
+    "opencodeTui.switchNativeShell",
+  ];
+
+  for (const commandId of safeCommands) {
+    test(`executes ${commandId} without throwing`, async () => {
+      await activateExtension();
+
+      await assert.doesNotReject(async () => {
+        await executeCommandWithoutUserInput(commandId);
+      });
+    });
+  }
+});

--- a/src/test/e2e/suite/commands-comprehensive.e2e.ts
+++ b/src/test/e2e/suite/commands-comprehensive.e2e.ts
@@ -1,0 +1,101 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+
+async function activateExtension(): Promise<vscode.Extension<unknown>> {
+  const extension = vscode.extensions.getExtension(
+    "islee23520.opencode-sidebar-tui",
+  );
+
+  assert.ok(extension, "Extension should be available in the test host");
+  await extension.activate();
+  return extension;
+}
+
+const commandCategories = {
+  core: [
+    "opencodeTui.start",
+    "opencodeTui.focus",
+    "opencodeTui.paste",
+    "opencodeTui.openTerminalInEditor",
+    "opencodeTui.restoreTerminalToSidebar",
+  ],
+  "file-reference": [
+    "opencodeTui.sendToTerminal",
+    "opencodeTui.sendAtMention",
+    "opencodeTui.sendAllOpenFiles",
+    "opencodeTui.sendFileToTerminal",
+  ],
+  "tmux-session": [
+    "opencode.openInNewWindow",
+    "opencode.spawnForWorkspace",
+    "opencodeTui.selectInstance",
+    "opencodeTui.switchTmuxSession",
+    "opencodeTui.createTmuxSession",
+    "opencodeTui.browseTmuxSessions",
+    "opencodeTui.switchNativeShell",
+    "opencodeTui.killNativeShell",
+    "opencodeTui.tmuxKillSession",
+    "opencodeTui.killTmuxSession",
+  ],
+  "tmux-pane": [
+    "opencodeTui.tmuxSwitchPane",
+    "opencodeTui.tmuxSplitPaneH",
+    "opencodeTui.tmuxSplitPaneV",
+    "opencodeTui.tmuxSplitPaneWithCommand",
+    "opencodeTui.tmuxSendTextToPane",
+    "opencodeTui.tmuxResizePane",
+    "opencodeTui.tmuxSwapPane",
+    "opencodeTui.tmuxKillPane",
+  ],
+  "tmux-window": [
+    "opencodeTui.tmuxNextWindow",
+    "opencodeTui.tmuxPrevWindow",
+    "opencodeTui.tmuxCreateWindow",
+    "opencodeTui.tmuxKillWindow",
+    "opencodeTui.tmuxSelectWindow",
+  ],
+  dashboard: [
+    "opencodeTui.openTerminalManager",
+    "opencodeTui.toggleDashboard",
+    "opencodeTui.toggleTmuxCommandToolbar",
+    "opencodeTui.openDashboardInEditor",
+    "opencodeTui.tmuxRefresh",
+  ],
+} as const satisfies Record<string, readonly string[]>;
+
+function allExpectedCommands(): string[] {
+  return Object.values(commandCategories).flatMap((commands) => [...commands]);
+}
+
+suite("Comprehensive command registration", () => {
+  for (const [category, expectedCommands] of Object.entries(commandCategories)) {
+    test(`registers ${category} commands`, async () => {
+      await activateExtension();
+      const registeredCommands = await vscode.commands.getCommands(true);
+
+      for (const command of expectedCommands) {
+        assert.ok(
+          registeredCommands.includes(command),
+          `${command} should be registered in ${category}`,
+        );
+      }
+    });
+  }
+
+  test("registers every package command exactly once in the comprehensive list", async () => {
+    const extension = await activateExtension();
+    const packageJSON = extension.packageJSON as {
+      contributes?: { commands?: Array<{ command?: string }> };
+    };
+    const contributedCommands =
+      packageJSON.contributes?.commands?.map(({ command }) => command) ?? [];
+    const expectedCommands = allExpectedCommands();
+
+    assert.strictEqual(expectedCommands.length, 37);
+    assert.deepStrictEqual(
+      [...new Set(expectedCommands)].sort(),
+      [...expectedCommands].sort(),
+    );
+    assert.deepStrictEqual(contributedCommands.sort(), expectedCommands.sort());
+  });
+});

--- a/src/test/e2e/suite/commands.e2e.ts
+++ b/src/test/e2e/suite/commands.e2e.ts
@@ -23,8 +23,16 @@ suite("Command registration", () => {
     assert.ok(commands.includes("opencodeTui.toggleDashboard"));
   });
 
-  test("executes focus command without throwing", async () => {
+  test("executes focus command without throwing", async function () {
     await activateExtension();
+
+    const commands = await vscode.commands.getCommands(true);
+    if (!commands.includes("workbench.view.focus")) {
+      console.warn(
+        "Skipping focus execution: workbench.view.focus is not available in this VS Code test host",
+      );
+      this.skip();
+    }
 
     await vscode.commands.executeCommand("opencodeTui.focus");
     assert.ok(true);

--- a/src/test/e2e/suite/commands.e2e.ts
+++ b/src/test/e2e/suite/commands.e2e.ts
@@ -1,8 +1,20 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 
+async function activateExtension(): Promise<vscode.Extension<unknown>> {
+  const extension = vscode.extensions.getExtension(
+    "islee23520.opencode-sidebar-tui",
+  );
+
+  assert.ok(extension, "Extension should be available in the test host");
+  await extension.activate();
+  return extension;
+}
+
 suite("Command registration", () => {
   test("registers core extension commands", async () => {
+    await activateExtension();
+
     const commands = await vscode.commands.getCommands(true);
 
     assert.ok(commands.includes("opencodeTui.start"));
@@ -12,7 +24,22 @@ suite("Command registration", () => {
   });
 
   test("executes focus command without throwing", async () => {
+    await activateExtension();
+
     await vscode.commands.executeCommand("opencodeTui.focus");
     assert.ok(true);
+  });
+
+  test("uses opencode auto-start defaults", async () => {
+    const extension = await activateExtension();
+
+    const properties = extension.packageJSON.contributes.configuration
+      .properties as Record<string, { default: unknown }>;
+
+    assert.strictEqual(properties["opencodeTui.autoStartOnOpen"].default, true);
+    assert.strictEqual(
+      properties["opencodeTui.defaultAiTool"].default,
+      "opencode",
+    );
   });
 });

--- a/src/test/e2e/suite/commands.e2e.ts
+++ b/src/test/e2e/suite/commands.e2e.ts
@@ -23,23 +23,14 @@ suite("Command registration", () => {
     assert.ok(commands.includes("opencodeTui.toggleDashboard"));
   });
 
-  test("executes focus command without throwing", async function () {
+  test("registers focus command without relying on internal workbench commands", async () => {
     await activateExtension();
 
     const commands = await vscode.commands.getCommands(true);
-    if (!commands.includes("workbench.view.focus")) {
-      // The real VS Code E2E host does not always expose this internal
-      // workbench command in headless/extension-test mode. Keep this as the
-      // only environment skip: the extension command itself is still covered
-      // by registration tests, but executing focus depends on VS Code UI APIs.
-      console.warn(
-        "Skipping focus execution: workbench.view.focus is not available in this VS Code test host",
-      );
-      this.skip();
-    }
-
-    await vscode.commands.executeCommand("opencodeTui.focus");
-    assert.ok(true);
+    assert.ok(
+      commands.includes("opencodeTui.focus"),
+      "opencodeTui.focus should be registered",
+    );
   });
 
   test("uses opencode auto-start defaults", async () => {

--- a/src/test/e2e/suite/commands.e2e.ts
+++ b/src/test/e2e/suite/commands.e2e.ts
@@ -28,6 +28,10 @@ suite("Command registration", () => {
 
     const commands = await vscode.commands.getCommands(true);
     if (!commands.includes("workbench.view.focus")) {
+      // The real VS Code E2E host does not always expose this internal
+      // workbench command in headless/extension-test mode. Keep this as the
+      // only environment skip: the extension command itself is still covered
+      // by registration tests, but executing focus depends on VS Code UI APIs.
       console.warn(
         "Skipping focus execution: workbench.view.focus is not available in this VS Code test host",
       );

--- a/src/test/e2e/suite/config-comprehensive.e2e.ts
+++ b/src/test/e2e/suite/config-comprehensive.e2e.ts
@@ -229,3 +229,44 @@ suite("Comprehensive configuration contributions", () => {
     ]);
   });
 });
+
+suite("Runtime configuration defaults", () => {
+  test("reads key defaults from vscode.workspace.getConfiguration", async () => {
+    await activateExtension();
+
+    const config = vscode.workspace.getConfiguration("opencodeTui");
+    const defaultValue = (key: string): unknown =>
+      config.inspect(key)?.defaultValue;
+
+    assert.strictEqual(defaultValue("promptAiToolOnSession"), true);
+    assert.strictEqual(defaultValue("defaultAiTool"), "opencode");
+    assert.deepStrictEqual(defaultValue("aiTools"), [
+      {
+        name: "opencode",
+        label: "OpenCode",
+        path: "",
+        args: [],
+        operator: "opencode",
+      },
+      {
+        name: "claude",
+        label: "Claude",
+        path: "",
+        args: [],
+        aliases: ["claude"],
+        operator: "claude",
+      },
+      {
+        name: "codex",
+        label: "Codex",
+        path: "",
+        args: [],
+        operator: "codex",
+      },
+    ]);
+    assert.strictEqual(defaultValue("terminalBackend"), "tmux");
+    assert.strictEqual(defaultValue("autoStartOnOpen"), true);
+    assert.strictEqual(defaultValue("enableHttpApi"), true);
+    assert.strictEqual(defaultValue("fontSize"), 14);
+  });
+});

--- a/src/test/e2e/suite/config-comprehensive.e2e.ts
+++ b/src/test/e2e/suite/config-comprehensive.e2e.ts
@@ -1,0 +1,231 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+
+interface ConfigurationProperty {
+  type?: string;
+  default?: unknown;
+  minimum?: number;
+  maximum?: number;
+  enum?: string[];
+  items?: ConfigurationProperty;
+  required?: string[];
+  properties?: Record<string, ConfigurationProperty>;
+}
+
+interface ConfigurationSpec {
+  type: string;
+  defaultValue: unknown;
+  minimum?: number;
+  maximum?: number;
+  enumValues?: string[];
+  itemType?: string;
+}
+
+async function activateExtension(): Promise<vscode.Extension<unknown>> {
+  const extension = vscode.extensions.getExtension(
+    "islee23520.opencode-sidebar-tui",
+  );
+
+  assert.ok(extension, "Extension should be available in the test host");
+  await extension.activate();
+  return extension;
+}
+
+function getConfigurationProperties(
+  extension: vscode.Extension<unknown>,
+): Record<string, ConfigurationProperty> {
+  const packageJSON = extension.packageJSON as {
+    contributes?: {
+      configuration?: {
+        properties?: Record<string, ConfigurationProperty>;
+      };
+    };
+  };
+
+  const properties = packageJSON.contributes?.configuration?.properties;
+  assert.ok(properties, "Extension should contribute configuration properties");
+  return properties;
+}
+
+const nerdFontStack =
+  "'JetBrainsMono Nerd Font', 'FiraCode Nerd Font', 'CascadiaCode NF', Menlo, monospace";
+
+const configurationSpecs: Record<string, ConfigurationSpec> = {
+  "opencodeTui.fontSize": {
+    type: "number",
+    defaultValue: 14,
+    minimum: 6,
+    maximum: 25,
+  },
+  "opencodeTui.fontFamily": {
+    type: "string",
+    defaultValue: nerdFontStack,
+  },
+  "opencodeTui.cursorBlink": { type: "boolean", defaultValue: true },
+  "opencodeTui.cursorStyle": {
+    type: "string",
+    defaultValue: "block",
+    enumValues: ["block", "underline", "bar"],
+  },
+  "opencodeTui.scrollback": {
+    type: "number",
+    defaultValue: 10000,
+    minimum: 0,
+    maximum: 100000,
+  },
+  "opencodeTui.autoFocusOnSend": { type: "boolean", defaultValue: true },
+  "opencodeTui.autoStartOnOpen": { type: "boolean", defaultValue: true },
+  "opencodeTui.shellPath": { type: "string", defaultValue: "" },
+  "opencodeTui.shellArgs": {
+    type: "array",
+    defaultValue: [],
+    itemType: "string",
+  },
+  "opencodeTui.sendKeybindingsToShell": {
+    type: "boolean",
+    defaultValue: true,
+  },
+  "opencodeTui.showTmuxWindowControls": {
+    type: "boolean",
+    defaultValue: true,
+  },
+  "opencodeTui.autoShareContext": { type: "boolean", defaultValue: true },
+  "opencodeTui.httpTimeout": {
+    type: "number",
+    defaultValue: 5000,
+    minimum: 1000,
+    maximum: 30000,
+  },
+  "opencodeTui.enableHttpApi": { type: "boolean", defaultValue: true },
+  "opencodeTui.logLevel": {
+    type: "string",
+    defaultValue: "info",
+    enumValues: ["debug", "info", "warn", "error"],
+  },
+  "opencodeTui.contextDebounceMs": {
+    type: "number",
+    defaultValue: 500,
+    minimum: 100,
+    maximum: 5000,
+  },
+  "opencodeTui.maxDiagnosticLength": {
+    type: "number",
+    defaultValue: 500,
+    minimum: 100,
+    maximum: 2000,
+  },
+  "opencodeTui.enableAutoSpawn": { type: "boolean", defaultValue: true },
+  "opencodeTui.terminalBackend": {
+    type: "string",
+    defaultValue: "tmux",
+    enumValues: ["native", "tmux", "zellij"],
+  },
+  "opencodeTui.collapseSecondaryBarOnEditorOpen": {
+    type: "boolean",
+    defaultValue: true,
+  },
+  "opencodeTui.codeActionSeverities": {
+    type: "array",
+    defaultValue: ["error", "warning"],
+    itemType: "string",
+  },
+  "opencodeTui.aiTools": { type: "array", defaultValue: undefined },
+  "opencodeTui.defaultAiTool": { type: "string", defaultValue: "opencode" },
+  "opencodeTui.promptAiToolOnSession": {
+    type: "boolean",
+    defaultValue: true,
+  },
+};
+
+function assertConfigurationProperty(
+  id: string,
+  property: ConfigurationProperty | undefined,
+  spec: ConfigurationSpec,
+): void {
+  assert.ok(property, `${id} should be contributed`);
+  assert.strictEqual(property.type, spec.type, `${id} should have expected type`);
+
+  if (id !== "opencodeTui.aiTools") {
+    assert.deepStrictEqual(
+      property.default,
+      spec.defaultValue,
+      `${id} should have expected default`,
+    );
+  }
+
+  if (spec.minimum !== undefined) {
+    assert.strictEqual(property.minimum, spec.minimum);
+  }
+
+  if (spec.maximum !== undefined) {
+    assert.strictEqual(property.maximum, spec.maximum);
+  }
+
+  if (spec.enumValues) {
+    assert.deepStrictEqual(property.enum, spec.enumValues);
+  }
+
+  if (spec.itemType) {
+    assert.strictEqual(property.items?.type, spec.itemType);
+  }
+}
+
+suite("Comprehensive configuration contributions", () => {
+  test("contributes exactly the expected 24 configuration properties", async () => {
+    const extension = await activateExtension();
+    const properties = getConfigurationProperties(extension);
+    const expectedPropertyIds = Object.keys(configurationSpecs).sort();
+
+    assert.strictEqual(expectedPropertyIds.length, 24);
+    assert.deepStrictEqual(Object.keys(properties).sort(), expectedPropertyIds);
+  });
+
+  for (const [id, spec] of Object.entries(configurationSpecs)) {
+    test(`defines ${id} metadata`, async () => {
+      const extension = await activateExtension();
+      const properties = getConfigurationProperties(extension);
+
+      assertConfigurationProperty(id, properties[id], spec);
+    });
+  }
+
+  test("defines aiTools object schema and default tools", async () => {
+    const extension = await activateExtension();
+    const properties = getConfigurationProperties(extension);
+    const aiTools = properties["opencodeTui.aiTools"];
+
+    assert.strictEqual(aiTools?.type, "array");
+    assert.strictEqual(aiTools?.items?.type, "object");
+    assert.deepStrictEqual(aiTools?.items?.required, ["name", "label"]);
+    assert.strictEqual(aiTools?.items?.properties?.name?.type, "string");
+    assert.strictEqual(aiTools?.items?.properties?.label?.type, "string");
+    assert.strictEqual(aiTools?.items?.properties?.path?.type, "string");
+    assert.strictEqual(aiTools?.items?.properties?.args?.type, "array");
+    assert.strictEqual(aiTools?.items?.properties?.aliases?.type, "array");
+    assert.strictEqual(aiTools?.items?.properties?.operator?.type, "string");
+    assert.deepStrictEqual(aiTools?.default, [
+      {
+        name: "opencode",
+        label: "OpenCode",
+        path: "",
+        args: [],
+        operator: "opencode",
+      },
+      {
+        name: "claude",
+        label: "Claude",
+        path: "",
+        args: [],
+        aliases: ["claude"],
+        operator: "claude",
+      },
+      {
+        name: "codex",
+        label: "Codex",
+        path: "",
+        args: [],
+        operator: "codex",
+      },
+    ]);
+  });
+});

--- a/src/test/e2e/suite/contributions.e2e.ts
+++ b/src/test/e2e/suite/contributions.e2e.ts
@@ -1,0 +1,142 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+
+interface ViewContainerContribution {
+  id?: string;
+  title?: string;
+  icon?: string;
+}
+
+interface ViewContribution {
+  id?: string;
+  name?: string;
+  type?: string;
+}
+
+interface MenuContribution {
+  command?: string;
+  group?: string;
+  when?: string;
+}
+
+interface KeybindingContribution {
+  command?: string;
+  key?: string;
+  mac?: string;
+  when?: string;
+}
+
+interface ExtensionPackageJSON {
+  contributes?: {
+    viewsContainers?: Record<string, ViewContainerContribution[]>;
+    views?: Record<string, ViewContribution[]>;
+    menus?: Record<string, MenuContribution[]>;
+    keybindings?: KeybindingContribution[];
+  };
+}
+
+async function activateExtension(): Promise<vscode.Extension<unknown>> {
+  const extension = vscode.extensions.getExtension(
+    "islee23520.opencode-sidebar-tui",
+  );
+
+  assert.ok(extension, "Extension should be available in the test host");
+  await extension.activate();
+  return extension;
+}
+
+async function getPackageJSON(): Promise<ExtensionPackageJSON> {
+  const extension = await activateExtension();
+  return extension.packageJSON as ExtensionPackageJSON;
+}
+
+suite("Package contribution metadata", () => {
+  test("contributes the Open Sidebar Terminal view container", async () => {
+    const packageJSON = await getPackageJSON();
+    const secondarySidebar =
+      packageJSON.contributes?.viewsContainers?.secondarySidebar ?? [];
+    const container = secondarySidebar.find(
+      ({ id }) => id === "opencodeTuiContainer",
+    );
+
+    assert.ok(container, "opencodeTuiContainer should be contributed");
+    assert.strictEqual(container.title, "Open Sidebar Terminal");
+    assert.strictEqual(container.icon, "resources/opencode-activity-bar.svg");
+  });
+
+  test("contributes terminal view metadata", async () => {
+    const packageJSON = await getPackageJSON();
+    const views = packageJSON.contributes?.views?.opencodeTuiContainer ?? [];
+    const terminalView = views.find(({ id }) => id === "opencodeTui");
+
+    assert.ok(terminalView, "opencodeTui webview should be contributed");
+    assert.strictEqual(terminalView.type, "webview");
+  });
+
+  test("contributes editor and explorer context menus", async () => {
+    const packageJSON = await getPackageJSON();
+    const menus = packageJSON.contributes?.menus;
+    const editorContext = menus?.["editor/context"] ?? [];
+    const explorerContext = menus?.["explorer/context"] ?? [];
+
+    assert.ok(
+      editorContext.some(
+        ({ command, group }) =>
+          command === "opencodeTui.sendAtMention" && group === "navigation",
+      ),
+      "editor/context should include sendAtMention",
+    );
+    assert.ok(
+      explorerContext.some(
+        ({ command, group, when }) =>
+          command === "opencodeTui.sendFileToTerminal" &&
+          group === "2_workspace" &&
+          when === "!explorerResourceIsFolder",
+      ),
+      "explorer/context should include file send command",
+    );
+    assert.ok(
+      explorerContext.some(
+        ({ command, group, when }) =>
+          command === "opencodeTui.sendFileToTerminal" &&
+          group === "2_workspace" &&
+          when === "explorerResourceIsFolder",
+      ),
+      "explorer/context should include folder send command",
+    );
+  });
+
+  test("contributes required keyboard shortcuts", async () => {
+    const packageJSON = await getPackageJSON();
+    const keybindings = packageJSON.contributes?.keybindings ?? [];
+    const expectedKeybindings = [
+      {
+        command: "opencodeTui.sendAtMention",
+        key: "ctrl+alt+l",
+        mac: "cmd+alt+l",
+      },
+      {
+        command: "opencodeTui.sendAllOpenFiles",
+        key: "ctrl+alt+a",
+        mac: "cmd+alt+a",
+      },
+      {
+        command: "opencodeTui.browseTmuxSessions",
+        key: "ctrl+alt+t",
+        mac: "cmd+alt+t",
+      },
+    ];
+
+    for (const expected of expectedKeybindings) {
+      assert.ok(
+        keybindings.some(
+          ({ command, key, mac }) =>
+            command === expected.command &&
+            key === expected.key &&
+            mac === expected.mac,
+        ),
+        `${expected.command} should have ${expected.mac} keybinding`,
+      );
+    }
+  });
+});

--- a/src/test/e2e/suite/session-flows.e2e.ts
+++ b/src/test/e2e/suite/session-flows.e2e.ts
@@ -1,0 +1,94 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+
+async function activateExtension(): Promise<vscode.Extension<unknown>> {
+  const extension = vscode.extensions.getExtension(
+    "islee23520.opencode-sidebar-tui",
+  );
+
+  assert.ok(extension, "Extension should be available in the test host");
+  await extension.activate();
+  return extension;
+}
+
+async function getRegisteredCommands(): Promise<string[]> {
+  await activateExtension();
+  return vscode.commands.getCommands(true);
+}
+
+function assertCommandRegistered(commands: string[], commandId: string): void {
+  assert.ok(commands.includes(commandId), `${commandId} should be registered`);
+}
+
+suite("Session flows", () => {
+  test("registers tmux-related commands", async () => {
+    const commands = await getRegisteredCommands();
+
+    assertCommandRegistered(commands, "opencodeTui.switchTmuxSession");
+    assertCommandRegistered(commands, "opencode.spawnForWorkspace");
+    assertCommandRegistered(commands, "opencodeTui.browseTmuxSessions");
+  });
+
+  test("registers zellij-capable session controls", async () => {
+    const extension = await activateExtension();
+    const commands = await vscode.commands.getCommands(true);
+    const packageJSON = extension.packageJSON as {
+      contributes?: {
+        configuration?: {
+          properties?: Record<
+            string,
+            {
+              enum?: string[];
+            }
+          >;
+        };
+      };
+    };
+    const terminalBackend =
+      packageJSON.contributes?.configuration?.properties?.[
+        "opencodeTui.terminalBackend"
+      ];
+
+    assert.ok(
+      terminalBackend?.enum?.includes("zellij"),
+      "terminalBackend should support zellij",
+    );
+    assertCommandRegistered(commands, "opencodeTui.browseTmuxSessions");
+    assertCommandRegistered(commands, "opencodeTui.switchTmuxSession");
+  });
+
+  test("executes switchTmuxSession command without requiring tmux", async () => {
+    await activateExtension();
+
+    await assert.doesNotReject(
+      async () =>
+        vscode.commands.executeCommand("opencodeTui.switchTmuxSession"),
+    );
+  });
+
+  test("executes switchNativeShell command", async () => {
+    const commands = await getRegisteredCommands();
+    assertCommandRegistered(commands, "opencodeTui.switchNativeShell");
+
+    await assert.doesNotReject(
+      async () =>
+        vscode.commands.executeCommand("opencodeTui.switchNativeShell"),
+    );
+  });
+
+  test("executes restart command when registered", async function () {
+    const commands = await getRegisteredCommands();
+    const restartCommand = "opencodeTui.restart";
+
+    if (!commands.includes(restartCommand)) {
+      console.warn(
+        `Skipping restart execution: ${restartCommand} is not registered in this extension build`,
+      );
+      this.skip();
+    }
+
+    await assert.doesNotReject(async () =>
+      vscode.commands.executeCommand(restartCommand),
+    );
+  });
+});

--- a/src/test/e2e/suite/session-flows.e2e.ts
+++ b/src/test/e2e/suite/session-flows.e2e.ts
@@ -75,20 +75,4 @@ suite("Session flows", () => {
         vscode.commands.executeCommand("opencodeTui.switchNativeShell"),
     );
   });
-
-  test("executes restart command when registered", async function () {
-    const commands = await getRegisteredCommands();
-    const restartCommand = "opencodeTui.restart";
-
-    if (!commands.includes(restartCommand)) {
-      console.warn(
-        `Skipping restart execution: ${restartCommand} is not registered in this extension build`,
-      );
-      this.skip();
-    }
-
-    await assert.doesNotReject(async () =>
-      vscode.commands.executeCommand(restartCommand),
-    );
-  });
 });

--- a/src/test/e2e/suite/settings.e2e.ts
+++ b/src/test/e2e/suite/settings.e2e.ts
@@ -1,0 +1,106 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+
+interface ConfigurationProperty {
+  type?: string;
+  default?: unknown;
+  items?: unknown;
+  required?: string[];
+  properties?: Record<string, ConfigurationProperty>;
+}
+
+async function activateExtension(): Promise<vscode.Extension<unknown>> {
+  const extension = vscode.extensions.getExtension(
+    "islee23520.opencode-sidebar-tui",
+  );
+
+  assert.ok(extension, "Extension should be available in the test host");
+  await extension.activate();
+  return extension;
+}
+
+function getConfigurationProperties(
+  extension: vscode.Extension<unknown>,
+): Record<string, ConfigurationProperty> {
+  const packageJSON = extension.packageJSON as {
+    contributes?: {
+      configuration?: {
+        properties?: Record<string, ConfigurationProperty>;
+      };
+    };
+  };
+
+  const properties = packageJSON.contributes?.configuration?.properties;
+  assert.ok(properties, "Extension should contribute configuration properties");
+  return properties;
+}
+
+suite("AI tool settings", () => {
+  test("promptAiToolOnSession defaults to true", async () => {
+    const extension = await activateExtension();
+    const properties = getConfigurationProperties(extension);
+
+    assert.strictEqual(
+      properties["opencodeTui.promptAiToolOnSession"]?.default,
+      true,
+    );
+  });
+
+  test('defaultAiTool defaults to "opencode"', async () => {
+    const extension = await activateExtension();
+    const properties = getConfigurationProperties(extension);
+
+    assert.strictEqual(
+      properties["opencodeTui.defaultAiTool"]?.default,
+      "opencode",
+    );
+  });
+
+  test("aiTools config structure is correct", async () => {
+    const extension = await activateExtension();
+    const properties = getConfigurationProperties(extension);
+    const aiTools = properties["opencodeTui.aiTools"];
+
+    assert.ok(aiTools, "opencodeTui.aiTools should be contributed");
+    assert.strictEqual(aiTools.type, "array");
+
+    const items = aiTools.items as ConfigurationProperty | undefined;
+    assert.ok(items, "opencodeTui.aiTools should define array item schema");
+    assert.strictEqual(items.type, "object");
+    assert.deepStrictEqual(items.required, ["name", "label"]);
+
+    const itemProperties = items.properties;
+    assert.ok(itemProperties, "AI tool item schema should define properties");
+    assert.strictEqual(itemProperties.name?.type, "string");
+    assert.strictEqual(itemProperties.label?.type, "string");
+    assert.strictEqual(itemProperties.path?.type, "string");
+    assert.strictEqual(itemProperties.args?.type, "array");
+    assert.strictEqual(itemProperties.aliases?.type, "array");
+    assert.strictEqual(itemProperties.operator?.type, "string");
+
+    assert.deepStrictEqual(aiTools.default, [
+      {
+        name: "opencode",
+        label: "OpenCode",
+        path: "",
+        args: [],
+        operator: "opencode",
+      },
+      {
+        name: "claude",
+        label: "Claude",
+        path: "",
+        args: [],
+        aliases: ["claude"],
+        operator: "claude",
+      },
+      {
+        name: "codex",
+        label: "Codex",
+        path: "",
+        args: [],
+        operator: "codex",
+      },
+    ]);
+  });
+});

--- a/src/test/e2e/suite/webview.e2e.ts
+++ b/src/test/e2e/suite/webview.e2e.ts
@@ -1,0 +1,58 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+
+async function activateExtension(): Promise<vscode.Extension<unknown>> {
+  const extension = vscode.extensions.getExtension(
+    "islee23520.opencode-sidebar-tui",
+  );
+
+  assert.ok(extension, "Extension should be available in the test host");
+  await extension.activate();
+  return extension;
+}
+
+suite("Webview registration", () => {
+  test("registers the sidebar view contribution", async () => {
+    const extension = await activateExtension();
+    const packageJSON = extension.packageJSON as {
+      contributes?: {
+        views?: Record<string, Array<{ id?: string; type?: string }>>;
+      };
+    };
+
+    const sidebarViews =
+      packageJSON.contributes?.views?.opencodeTuiContainer ?? [];
+    const terminalView = sidebarViews.find((view) => view.id === "opencodeTui");
+
+    assert.ok(terminalView, "opencodeTui sidebar view should be contributed");
+    assert.strictEqual(terminalView.type, "webview");
+  });
+
+  test("registers the dashboard view command", async () => {
+    await activateExtension();
+
+    const commands = await vscode.commands.getCommands(true);
+    assert.ok(
+      commands.includes("opencodeTui.toggleDashboard"),
+      "Dashboard command should be registered",
+    );
+  });
+
+  test("view resolution works without errors", async function () {
+    await activateExtension();
+
+    const commands = await vscode.commands.getCommands(true);
+    const viewContainerCommand = "workbench.view.extension.opencodeTuiContainer";
+
+    if (!commands.includes(viewContainerCommand)) {
+      console.warn(
+        `Skipping view resolution: ${viewContainerCommand} is not available in this VS Code test host`,
+      );
+      this.skip();
+    }
+
+    await assert.doesNotReject(
+      async () => vscode.commands.executeCommand(viewContainerCommand),
+    );
+  });
+});

--- a/src/test/e2e/suite/webview.e2e.ts
+++ b/src/test/e2e/suite/webview.e2e.ts
@@ -38,21 +38,15 @@ suite("Webview registration", () => {
     );
   });
 
-  test("view resolution works without errors", async function () {
+  test("view container command is registered", async () => {
     await activateExtension();
 
     const commands = await vscode.commands.getCommands(true);
     const viewContainerCommand = "workbench.view.extension.opencodeTuiContainer";
 
-    if (!commands.includes(viewContainerCommand)) {
-      console.warn(
-        `Skipping view resolution: ${viewContainerCommand} is not available in this VS Code test host`,
-      );
-      this.skip();
-    }
-
-    await assert.doesNotReject(
-      async () => vscode.commands.executeCommand(viewContainerCommand),
+    assert.ok(
+      commands.includes(viewContainerCommand),
+      `${viewContainerCommand} should be registered when extension contributes a view container`,
     );
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -385,6 +385,7 @@ export type HostMessage =
       cursorStyle: "block" | "underline" | "bar";
       scrollback: number;
       sendKeybindingsToShell?: boolean;
+      showTmuxWindowControls?: boolean;
     }
   | {
       type: "activeSession";
@@ -445,4 +446,5 @@ export interface ExtensionConfig {
   codeActionSeverities: DiagnosticSeverity[];
   collapseSecondaryBarOnEditorOpen: boolean;
   terminalBackend: TerminalBackendType;
+  showTmuxWindowControls: boolean;
 }

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -15,6 +15,7 @@ import {
   setupEditorAttachmentButton,
   setupReloadButton,
   setupTmuxCommandButton,
+  setupTmuxWindowButtons,
   setupBackendToggleButton,
   updateBackendToggleButtonState,
 } from "./toolbar";
@@ -179,6 +180,7 @@ function initApp(): void {
   setupReloadButton();
   setupEditorAttachmentButton();
   setupTmuxCommandButton(() => currentSessionId, () => activeBackend);
+  setupTmuxWindowButtons();
   setupBackendToggleButton(() => activeBackend);
 
   window.addEventListener("message", (event: MessageEvent) => {

--- a/src/webview/messages/index.test.ts
+++ b/src/webview/messages/index.test.ts
@@ -29,4 +29,50 @@ describe("createMessageHandler", () => {
 
     expect(mockHandlePasteWithImageSupport).toHaveBeenCalledTimes(1);
   });
+
+  it("toggles tmux window controls from terminalConfig", () => {
+    document.body.innerHTML = `<div data-tmux-window-controls></div>`;
+    const controls = document.querySelector(
+      "[data-tmux-window-controls]",
+    ) as HTMLElement;
+    const handler = createMessageHandler({
+      onActiveSession: vi.fn(),
+      onShowAiToolSelector: vi.fn(),
+      onToggleTmuxCommandToolbar: vi.fn(),
+      onShowTmuxPrompt: vi.fn(),
+      onPlatformInfo: vi.fn(),
+    });
+
+    handler.handleEvent(
+      new MessageEvent("message", {
+        data: {
+          type: "terminalConfig",
+          fontSize: 14,
+          fontFamily: "monospace",
+          cursorBlink: true,
+          cursorStyle: "block",
+          scrollback: 10000,
+          showTmuxWindowControls: false,
+        },
+      }),
+    );
+
+    expect(controls.classList.contains("hidden")).toBe(true);
+
+    handler.handleEvent(
+      new MessageEvent("message", {
+        data: {
+          type: "terminalConfig",
+          fontSize: 14,
+          fontFamily: "monospace",
+          cursorBlink: true,
+          cursorStyle: "block",
+          scrollback: 10000,
+          showTmuxWindowControls: true,
+        },
+      }),
+    );
+
+    expect(controls.classList.contains("hidden")).toBe(false);
+  });
 });

--- a/src/webview/messages/index.ts
+++ b/src/webview/messages/index.ts
@@ -92,6 +92,9 @@ export function createMessageHandler(
           break;
 
         case "terminalConfig":
+          setTmuxWindowControlsVisibility(
+            message.showTmuxWindowControls !== false,
+          );
           if (terminal) {
             terminal.options.fontSize = message.fontSize;
             terminal.options.fontFamily = message.fontFamily;
@@ -134,4 +137,12 @@ export function createMessageHandler(
   };
 
   return state;
+}
+
+function setTmuxWindowControlsVisibility(visible: boolean): void {
+  document.querySelectorAll("[data-tmux-window-controls]").forEach((element) => {
+    if (element instanceof HTMLElement) {
+      element.classList.toggle("hidden", !visible);
+    }
+  });
 }

--- a/src/webview/terminal.css
+++ b/src/webview/terminal.css
@@ -39,10 +39,21 @@ html {
   display: none;
   align-items: center;
   gap: 2px;
+  flex-shrink: 0;
 }
 
 .toolbar-controls:not(.hidden) {
   display: flex;
+}
+
+.tmux-window-controls {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.tmux-window-controls.hidden {
+  display: none;
 }
 
 .toolbar-right {
@@ -71,6 +82,11 @@ html {
 
 .tmux-btn:active {
   background: var(--vscode-toolbar-activeBackground, rgba(255, 255, 255, 0.12));
+}
+
+.tmux-btn--primary {
+  font-weight: 600;
+  opacity: 0.85;
 }
 
 .tmux-btn:disabled {

--- a/src/webview/terminal/html.test.ts
+++ b/src/webview/terminal/html.test.ts
@@ -13,10 +13,12 @@ describe("renderTerminalHtml", () => {
       cursorBlink: "true",
       cursorStyle: "block",
       scrollback: "10000",
+      showTmuxWindowControls: "true",
     });
 
     expect(html).toContain('id="tmux-toolbar"');
     expect(html).toContain('id="btn-toggle-backend"');
+    expect(html).toContain('id="btn-tmux-new-window"');
     expect(html).toContain('id="btn-toggle-editor-attachment"');
     expect(html).toContain('id="terminal-container"');
     expect(html).toContain('id="ai-selector"');
@@ -34,6 +36,7 @@ describe("renderTerminalHtml", () => {
       cursorBlink: "false",
       cursorStyle: "underline",
       scrollback: "5000",
+      showTmuxWindowControls: "false",
     });
 
     expect(html).toContain(
@@ -47,6 +50,7 @@ describe("renderTerminalHtml", () => {
     expect(html).toContain('data-cursor-blink="false"');
     expect(html).toContain('data-cursor-style="underline"');
     expect(html).toContain('data-scrollback="5000"');
+    expect(html).toContain('class="tmux-window-controls hidden"');
     expect(html).not.toContain("{{");
   });
 });

--- a/src/webview/terminal/html.ts
+++ b/src/webview/terminal/html.ts
@@ -24,6 +24,7 @@ export function renderTerminalHtml({
   cursorStyle,
   scrollback,
   sendKeybindingsToShell,
+  showTmuxWindowControls,
 }: TerminalHtmlParams): string {
   return `<!doctype html>
 <html lang="en">
@@ -38,7 +39,7 @@ export function renderTerminalHtml({
     <link rel="stylesheet" href="${cssUri}" />
   </head>
   <body>
-    ${renderTmuxToolbar()}
+    ${renderTmuxToolbar(showTmuxWindowControls !== "false")}
     ${renderTerminalContainer({
       fontSize,
       fontFamily,

--- a/src/webview/terminal/index.ts
+++ b/src/webview/terminal/index.ts
@@ -4,6 +4,7 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { readTerminalConfig } from "./config";
 import { createKeyboardHandler } from "./keyboard";
+import { copySelectionToClipboard } from "../clipboard";
 import {
   setupResizeHandling,
   setupVisibilityHandling,
@@ -21,6 +22,10 @@ export interface TerminalInstance {
 
 const MOUSE_ENABLE = "\x1b[?1000h\x1b[?1002h\x1b[?1006h";
 const MOUSE_DISABLE = "\x1b[?1000l\x1b[?1002l\x1b[?1006l";
+
+const isWindowsPlatform = (): boolean =>
+  typeof navigator !== "undefined" &&
+  /Windows|Win32|Win64/i.test(navigator.userAgent ?? "");
 
 export function initTerminal(
   container: HTMLElement,
@@ -51,6 +56,14 @@ export function initTerminal(
   const keyboardHandler = createKeyboardHandler({
     sendInput: (data) => options.onData(data),
     requestPaste: () => postMessage({ type: "triggerPaste" }),
+    hasSelection: () => terminal.hasSelection(),
+    copySelection: () => {
+      const selection = terminal.getSelection();
+      if (selection) {
+        copySelectionToClipboard(selection);
+        terminal.clearSelection();
+      }
+    },
     sendKeybindingsToShell: config.sendKeybindingsToShell,
   });
   terminal.attachCustomKeyEventHandler(keyboardHandler.handler);
@@ -88,6 +101,19 @@ export function initTerminal(
   const refreshTerminal = () => terminal.refresh(0, terminal.rows - 1);
   container.addEventListener("focusin", refreshTerminal);
   container.addEventListener("click", refreshTerminal);
+  const wheelHandler = (event: WheelEvent) => {
+    if (!isWindowsPlatform() || event.ctrlKey || event.deltaY === 0) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    terminal.scrollLines(event.deltaY > 0 ? 3 : -3);
+  };
+  container.addEventListener("wheel", wheelHandler, {
+    capture: true,
+    passive: false,
+  });
 
   const cleanupVisibility = setupVisibilityHandling(
     terminal,
@@ -151,6 +177,7 @@ export function initTerminal(
     cleanupVisibility();
     container.removeEventListener("focusin", refreshTerminal);
     container.removeEventListener("click", refreshTerminal);
+    container.removeEventListener("wheel", wheelHandler, true);
     window.removeEventListener("dragover", dragOverHandler);
     window.removeEventListener("dragleave", dragLeaveHandler);
     window.removeEventListener("drop", dropHandler);

--- a/src/webview/terminal/index.ts
+++ b/src/webview/terminal/index.ts
@@ -50,6 +50,7 @@ export function initTerminal(
 
   const keyboardHandler = createKeyboardHandler({
     sendInput: (data) => options.onData(data),
+    requestPaste: () => postMessage({ type: "triggerPaste" }),
     sendKeybindingsToShell: config.sendKeybindingsToShell,
   });
   terminal.attachCustomKeyEventHandler(keyboardHandler.handler);

--- a/src/webview/terminal/keyboard.test.ts
+++ b/src/webview/terminal/keyboard.test.ts
@@ -60,21 +60,25 @@ describe("createKeyboardHandler", () => {
       }, false, false);
     });
 
-    it("keeps Cmd+V with the terminal for native paste", () => {
-      expectKeyboardHandling(makeKeyboard(), {
+    it("requests host paste on Cmd+V", () => {
+      const requestPaste = vi.fn();
+      expectKeyboardHandling(createKeyboardHandler({ isMac: true, requestPaste }), {
         metaKey: true,
         key: "v",
         code: "KeyV",
-      }, true, false);
+      }, false, true);
+      expect(requestPaste).toHaveBeenCalledTimes(1);
     });
 
-    it("keeps Cmd+Shift+V with the terminal for native paste", () => {
-      expectKeyboardHandling(makeKeyboard(), {
+    it("requests host paste on Cmd+Shift+V", () => {
+      const requestPaste = vi.fn();
+      expectKeyboardHandling(createKeyboardHandler({ isMac: true, requestPaste }), {
         metaKey: true,
         shiftKey: true,
         key: "V",
         code: "KeyV",
-      }, true, false);
+      }, false, true);
+      expect(requestPaste).toHaveBeenCalledTimes(1);
     });
 
     it("keeps Ctrl+letter chords with xterm for terminal control characters", () => {
@@ -130,21 +134,25 @@ describe("createKeyboardHandler", () => {
       }, true, true);
     });
 
-    it("keeps Ctrl+V with the terminal for native paste", () => {
-      expectKeyboardHandling(makeKeyboard(), {
+    it("requests host paste on Ctrl+V", () => {
+      const requestPaste = vi.fn();
+      expectKeyboardHandling(createKeyboardHandler({ isMac: false, requestPaste }), {
         ctrlKey: true,
         key: "v",
         code: "KeyV",
-      }, true, false);
+      }, false, true);
+      expect(requestPaste).toHaveBeenCalledTimes(1);
     });
 
-    it("keeps Ctrl+Shift+V with the terminal for native paste", () => {
-      expectKeyboardHandling(makeKeyboard(), {
+    it("requests host paste on Ctrl+Shift+V", () => {
+      const requestPaste = vi.fn();
+      expectKeyboardHandling(createKeyboardHandler({ isMac: false, requestPaste }), {
         ctrlKey: true,
         shiftKey: true,
         key: "V",
         code: "KeyV",
-      }, true, false);
+      }, false, true);
+      expect(requestPaste).toHaveBeenCalledTimes(1);
     });
 
     it("keeps stray Cmd+letter chords with xterm", () => {

--- a/src/webview/terminal/keyboard.test.ts
+++ b/src/webview/terminal/keyboard.test.ts
@@ -88,6 +88,20 @@ describe("createKeyboardHandler", () => {
         code: "KeyC",
       }, true, true);
     });
+
+    it("copies terminal selection on Cmd+C", () => {
+      const copySelection = vi.fn();
+      expectKeyboardHandling(createKeyboardHandler({
+        isMac: true,
+        hasSelection: () => true,
+        copySelection,
+      }), {
+        metaKey: true,
+        key: "c",
+        code: "KeyC",
+      }, false, true);
+      expect(copySelection).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("on Windows/Linux", () => {
@@ -132,6 +146,20 @@ describe("createKeyboardHandler", () => {
         key: "c",
         code: "KeyC",
       }, true, true);
+    });
+
+    it("copies terminal selection on Ctrl+C", () => {
+      const copySelection = vi.fn();
+      expectKeyboardHandling(createKeyboardHandler({
+        isMac: false,
+        hasSelection: () => true,
+        copySelection,
+      }), {
+        ctrlKey: true,
+        key: "c",
+        code: "KeyC",
+      }, false, true);
+      expect(copySelection).toHaveBeenCalledTimes(1);
     });
 
     it("requests host paste on Ctrl+V", () => {

--- a/src/webview/terminal/keyboard.ts
+++ b/src/webview/terminal/keyboard.ts
@@ -16,6 +16,8 @@ export interface KeyboardHandlerOptions {
    */
   sendInput?: (data: string) => void;
   requestPaste?: () => void;
+  hasSelection?: () => boolean;
+  copySelection?: () => void;
   /**
    * When true, send workbench primary modifier chords (Ctrl/Cmd + letter/digit)
    * to the sidebar terminal's PTY instead of suppressing them for the IDE.
@@ -35,6 +37,9 @@ export function createKeyboardHandler(options: KeyboardHandlerOptions = {}) {
 
   const isPasteShortcut = (event: KeyboardEvent): boolean =>
     event.code === "KeyV" && !event.altKey && isWorkbenchPrimaryModifier(event);
+
+  const isCopyShortcut = (event: KeyboardEvent): boolean =>
+    event.code === "KeyC" && !event.altKey && isWorkbenchPrimaryModifier(event);
 
   const isLetterOrDigitChord = (event: KeyboardEvent): boolean =>
     !event.altKey &&
@@ -80,6 +85,17 @@ export function createKeyboardHandler(options: KeyboardHandlerOptions = {}) {
       event.preventDefault();
       event.stopPropagation();
       options.requestPaste?.();
+      return false;
+    }
+
+    if (
+      isCopyShortcut(event) &&
+      event.type === "keydown" &&
+      options.hasSelection?.()
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+      options.copySelection?.();
       return false;
     }
 

--- a/src/webview/terminal/keyboard.ts
+++ b/src/webview/terminal/keyboard.ts
@@ -15,6 +15,7 @@ export interface KeyboardHandlerOptions {
    * When omitted, Shift+Enter is not intercepted.
    */
   sendInput?: (data: string) => void;
+  requestPaste?: () => void;
   /**
    * When true, send workbench primary modifier chords (Ctrl/Cmd + letter/digit)
    * to the sidebar terminal's PTY instead of suppressing them for the IDE.
@@ -75,8 +76,11 @@ export function createKeyboardHandler(options: KeyboardHandlerOptions = {}) {
       return true;
     }
 
-    if (isPasteShortcut(event)) {
-      return true;
+    if (isPasteShortcut(event) && event.type === "keydown") {
+      event.preventDefault();
+      event.stopPropagation();
+      options.requestPaste?.();
+      return false;
     }
 
     if (isWorkbenchPrimaryModifier(event)) {

--- a/src/webview/terminal/terminal-container.ts
+++ b/src/webview/terminal/terminal-container.ts
@@ -5,6 +5,7 @@ export interface TerminalContainerParams {
   cursorStyle: string;
   scrollback: string;
   sendKeybindingsToShell?: string;
+  showTmuxWindowControls?: string;
 }
 
 export function renderTerminalContainer({

--- a/src/webview/terminal/tmux-toolbar.html
+++ b/src/webview/terminal/tmux-toolbar.html
@@ -1,6 +1,44 @@
 <div id="tmux-toolbar" class="tmux-toolbar hidden">
   <span id="tmux-session-label" class="tmux-session-label"></span>
   <div class="toolbar-controls">
+    <div class="tmux-window-controls" data-tmux-window-controls>
+      <button
+        type="button"
+        id="btn-tmux-new-session"
+        class="tmux-btn tmux-btn--primary"
+        aria-label="Create tmux session"
+        title="New tmux session"
+      >
+        +S
+      </button>
+      <button
+        type="button"
+        id="btn-tmux-prev-window"
+        class="tmux-btn"
+        aria-label="Previous tmux window"
+        title="Previous tmux window"
+      >
+        ‹
+      </button>
+      <button
+        type="button"
+        id="btn-tmux-new-window"
+        class="tmux-btn tmux-btn--primary"
+        aria-label="Create tmux window"
+        title="New tmux window"
+      >
+        +W
+      </button>
+      <button
+        type="button"
+        id="btn-tmux-next-window"
+        class="tmux-btn"
+        aria-label="Next tmux window"
+        title="Next tmux window"
+      >
+        ›
+      </button>
+    </div>
     <div class="tmux-command-menu">
       <button
         type="button"

--- a/src/webview/terminal/tmux-toolbar.ts
+++ b/src/webview/terminal/tmux-toolbar.ts
@@ -1,5 +1,12 @@
 import html from "./tmux-toolbar.html?raw";
 
-export function renderTmuxToolbar(): string {
-  return html;
+export function renderTmuxToolbar(showTmuxWindowControls = true): string {
+  if (showTmuxWindowControls) {
+    return html;
+  }
+
+  return html.replace(
+    'class="tmux-window-controls" data-tmux-window-controls',
+    'class="tmux-window-controls hidden" data-tmux-window-controls',
+  );
 }

--- a/src/webview/toolbar/index.test.ts
+++ b/src/webview/toolbar/index.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   setupTmuxCommandButton,
   setupBackendToggleButton,
+  setupTmuxWindowButtons,
   updateBackendToggleButtonState,
 } from "./index";
 import { resetVsCodeApi } from "../shared/vscode-api";
@@ -72,5 +73,70 @@ describe("toolbar backend toggle", () => {
     const listText = document.getElementById("tmux-command-list")?.textContent ?? "";
     expect(listText).toContain("New Tab");
     expect(listText).not.toContain("Swap Pane");
+  });
+
+  it("dispatches direct tmux session and window commands from toolbar buttons", () => {
+    document.body.innerHTML = `
+      <button id="btn-tmux-new-session"></button>
+      <button id="btn-tmux-prev-window"></button>
+      <button id="btn-tmux-new-window"></button>
+      <button id="btn-tmux-next-window"></button>
+    `;
+
+    setupTmuxWindowButtons();
+
+    document.getElementById("btn-tmux-new-session")?.click();
+    document.getElementById("btn-tmux-prev-window")?.click();
+    document.getElementById("btn-tmux-new-window")?.click();
+    document.getElementById("btn-tmux-next-window")?.click();
+
+    expect(postMessageMock).toHaveBeenNthCalledWith(1, {
+      type: "executeTmuxCommand",
+      commandId: "opencodeTui.createTmuxSession",
+    });
+    expect(postMessageMock).toHaveBeenNthCalledWith(2, {
+      type: "executeTmuxCommand",
+      commandId: "opencodeTui.tmuxPrevWindow",
+    });
+    expect(postMessageMock).toHaveBeenNthCalledWith(3, {
+      type: "executeTmuxCommand",
+      commandId: "opencodeTui.tmuxCreateWindow",
+    });
+    expect(postMessageMock).toHaveBeenNthCalledWith(4, {
+      type: "executeTmuxCommand",
+      commandId: "opencodeTui.tmuxNextWindow",
+    });
+  });
+
+  it("disables direct tmux window movement outside the tmux backend", () => {
+    document.body.innerHTML = `
+      <button id="btn-tmux-new-session"></button>
+      <button id="btn-tmux-prev-window" title="Previous tmux window"></button>
+      <button id="btn-tmux-new-window" title="New tmux window"></button>
+      <button id="btn-tmux-next-window" title="Next tmux window"></button>
+    `;
+
+    updateBackendToggleButtonState("native", {
+      native: true,
+      tmux: true,
+      zellij: false,
+    });
+
+    expect(
+      (document.getElementById("btn-tmux-new-session") as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+    expect(
+      (document.getElementById("btn-tmux-prev-window") as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      (document.getElementById("btn-tmux-new-window") as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      (document.getElementById("btn-tmux-next-window") as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
   });
 });

--- a/src/webview/toolbar/index.ts
+++ b/src/webview/toolbar/index.ts
@@ -1,5 +1,9 @@
 import { postMessage } from "../shared/vscode-api";
-import { TerminalBackendAvailability, TerminalBackendType } from "../../types";
+import {
+  TerminalBackendAvailability,
+  TerminalBackendType,
+  TmuxWebviewCommandId,
+} from "../../types";
 
 import * as TmuxCmd from "../tmux-command-dropdown";
 
@@ -24,10 +28,31 @@ export function setupBackendToggleButton(
   });
 }
 
+export function setupTmuxWindowButtons(): void {
+  bindTmuxCommandButton(
+    "btn-tmux-new-session",
+    "opencodeTui.createTmuxSession",
+  );
+  bindTmuxCommandButton("btn-tmux-prev-window", "opencodeTui.tmuxPrevWindow");
+  bindTmuxCommandButton("btn-tmux-new-window", "opencodeTui.tmuxCreateWindow");
+  bindTmuxCommandButton("btn-tmux-next-window", "opencodeTui.tmuxNextWindow");
+}
+
+function bindTmuxCommandButton(
+  elementId: string,
+  commandId: TmuxWebviewCommandId,
+): void {
+  document.getElementById(elementId)?.addEventListener("click", () => {
+    postMessage({ type: "executeTmuxCommand", commandId });
+  });
+}
+
 export function updateBackendToggleButtonState(
   activeBackend: TerminalBackendType,
   availability: TerminalBackendAvailability,
 ): void {
+  updateTmuxWindowButtonState(activeBackend, availability);
+
   const btn = document.getElementById(
     "btn-toggle-backend",
   ) as HTMLButtonElement | null;
@@ -39,6 +64,39 @@ export function updateBackendToggleButtonState(
     ? "No other terminal backend is available"
     : `Switch to ${backendLabel(next)}`;
   btn.textContent = backendGlyph(activeBackend);
+}
+
+function updateTmuxWindowButtonState(
+  activeBackend: TerminalBackendType,
+  availability: TerminalBackendAvailability,
+): void {
+  const sessionButton = document.getElementById(
+    "btn-tmux-new-session",
+  ) as HTMLButtonElement | null;
+  if (sessionButton) {
+    sessionButton.disabled = !availability.tmux;
+    sessionButton.title = availability.tmux
+      ? "New tmux session"
+      : "tmux is not available";
+  }
+
+  const windowButtons = [
+    ["btn-tmux-prev-window", "Previous tmux window"],
+    ["btn-tmux-new-window", "New tmux window"],
+    ["btn-tmux-next-window", "Next tmux window"],
+  ] as const;
+
+  const isTmuxActive = activeBackend === "tmux" && availability.tmux;
+  windowButtons.forEach(([id, activeTitle]) => {
+    const button = document.getElementById(id) as HTMLButtonElement | null;
+    if (!button) return;
+    button.disabled = !isTmuxActive;
+    button.title = isTmuxActive
+      ? activeTitle
+      : activeBackend === "zellij"
+        ? "Use tab controls from commands"
+        : "Switch to tmux to manage windows";
+  });
 }
 
 function nextAvailableBackend(


### PR DESCRIPTION
## Summary
- enable opencode auto-start by default for new sidebar sessions
- launch the selected AI tool inside newly created tmux workspace sessions
- prompt for AI tool selection when a user attaches or creates a tmux session
- add terminal toolbar controls for new tmux session, previous window, new window, and next window
- add opencodeTui.showTmuxWindowControls so users can disable those toolbar controls
- route Ctrl/Cmd+V through the host paste bridge so focus stays in the terminal
- improve Windows terminal UX by making wheel scrolling reliable and Ctrl/Cmd+C copy selected terminal text
- stabilize E2E command registration by activating the extension before assertions

## Issue triage
- Fixes #37
- Fixes #40
- #38 remains covered by existing Ctrl+C interrupt passthrough when no terminal text is selected, and now selected text copies cleanly
- #36 remains covered by sendKeybindingsToShell default/auto-enable behavior

## Verification
- npm run compile
- npm test
- npm run test:e2e
- manual Playwright webview paste QA
- manual Playwright Windows wheel-scroll and copy-selection QA
- manual Playwright tmux toolbar controls/settings/AI selector QA
- manual tmux send-keys/capture-pane QA