### PR TITLE
fix(webview): mouse wheel tracking + Shift+Enter line feed

### DIFF
--- a/src/webview/terminal/index.ts
+++ b/src/webview/terminal/index.ts
@@ -106,6 +106,13 @@ export function initTerminal(
       return;
     }
 
+    // When a TUI enables mouse tracking (e.g. \x1b[?1002h),
+    // let xterm.js handle the wheel event so it sends the
+    // escape sequence to the PTY for the application to process.
+    if (terminal.modes.mouseTrackingMode !== "none") {
+      return;
+    }
+
     event.preventDefault();
     event.stopPropagation();
     terminal.scrollLines(event.deltaY > 0 ? 3 : -3);

--- a/src/webview/terminal/keyboard.test.ts
+++ b/src/webview/terminal/keyboard.test.ts
@@ -233,7 +233,7 @@ describe("createKeyboardHandler", () => {
   });
 
   describe("Shift+Enter handling", () => {
-    it("sends \\r\\n through sendInput on Shift+Enter", () => {
+    it("sends \\n through sendInput on Shift+Enter", () => {
       const sendInput = vi.fn();
       const keyboard = createKeyboardHandler({ isMac: true, sendInput });
 
@@ -245,7 +245,7 @@ describe("createKeyboardHandler", () => {
 
       expect(keyboard.handler(event)).toBe(false);
       expect(event.defaultPrevented).toBe(true);
-      expect(sendInput).toHaveBeenCalledWith("\r\n");
+      expect(sendInput).toHaveBeenCalledWith("\n");
     });
 
     it("does not intercept Shift+Enter when Ctrl is held", () => {
@@ -320,7 +320,7 @@ describe("createKeyboardHandler", () => {
       expect(keyboard.handler(event)).toBe(true);
     });
 
-    it("sends \\r\\n on Windows/Linux Shift+Enter", () => {
+    it("sends \\n on Windows/Linux Shift+Enter", () => {
       const sendInput = vi.fn();
       const keyboard = createKeyboardHandler({ isMac: false, sendInput });
 
@@ -332,7 +332,7 @@ describe("createKeyboardHandler", () => {
 
       expect(keyboard.handler(event)).toBe(false);
       expect(event.defaultPrevented).toBe(true);
-      expect(sendInput).toHaveBeenCalledWith("\r\n");
+      expect(sendInput).toHaveBeenCalledWith("\n");
     });
   });
 });

--- a/src/webview/terminal/keyboard.ts
+++ b/src/webview/terminal/keyboard.ts
@@ -10,7 +10,7 @@ export interface KeyboardHandlerOptions {
   isMac?: boolean;
   /**
    * Callback to send input data through the PTY/host path.
-   * When provided, Shift+Enter sends `\r\n` (multiline newline) via this
+   * When provided, Shift+Enter sends `\n` (multiline newline) via this
    * callback instead of through xterm's default key processing.
    * When omitted, Shift+Enter is not intercepted.
    */
@@ -73,7 +73,7 @@ export function createKeyboardHandler(options: KeyboardHandlerOptions = {}) {
     if (isShiftEnter(event) && event.type === "keydown" && options.sendInput) {
       event.preventDefault();
       event.stopPropagation();
-      options.sendInput("\r\n");
+      options.sendInput("\n");
       return false;
     }
 


### PR DESCRIPTION
## fix(webview): skip Windows wheel interception when mouse tracking is active

### Problem

On Windows, mouse wheel scrolling does not work when a TUI program (e.g. opencode) that enables mouse tracking mode is running in the terminal.

### Root Cause

The capture-phase wheel handler in `src/webview/terminal/index.ts` unconditionally intercepts all wheel events on Windows and calls `terminal.scrollLines()`. When a TUI enables mouse tracking (e.g. `\x1b[?1002h`), xterm.js should forward wheel events to the PTY as escape sequences for the application to handle. The custom handler blocks this by calling `preventDefault()` + `stopPropagation()` before xterm can process the event.

### Fix

Check `terminal.modes.mouseTrackingMode` before intercepting. When a TUI has mouse tracking active, skip the custom handler and let xterm.js handle the wheel event natively (forwarding escape sequences to the PTY).

### Testing

- Verified on Windows: scrolling works in both shell prompt and TUI (opencode) scenarios
- TypeScript type check passes (`tsc --noEmit`)

---

## fix(webview): send LF instead of CRLF on Shift+Enter

### Problem

Shift+Enter for multiline input was sending both CR and LF (`\r\n`), which in some shells/contexts behaves differently from a plain newline.

### Fix

Changed the input handler in `src/webview/terminal/keyboard.ts` to send `\n` (LF) instead of `\r\n` (CRLF) on Shift+Enter, consistent with standard terminal newline behavior.

### Testing

- Updated keyboard unit tests to verify LF output
- Verified multiline input works correctly in terminal