### PR TITLE
fix(webview): route paste shortcuts through host

### DIFF
--- a/src/webview/terminal/index.test.ts
+++ b/src/webview/terminal/index.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { describe, expect, it, vi } from "vitest";
-import { createWheelHandler } from "./index";
+import { createContextMenuPasteHandler, createWheelHandler } from "./index";
 
 const createWheelEvent = (
   init: WheelEventInit,
@@ -149,5 +149,23 @@ describe("createWheelHandler", () => {
       expect(scrollLines).toHaveBeenCalledWith(3);
       expect(event.defaultPrevented).toBe(true);
     });
+  });
+});
+
+describe("createContextMenuPasteHandler", () => {
+  it("requests host paste and suppresses the browser menu on right-click", () => {
+    const requestPaste = vi.fn();
+    const handler = createContextMenuPasteHandler({ requestPaste });
+    const event = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+    });
+    const stopSpy = vi.spyOn(event, "stopPropagation");
+
+    handler(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(stopSpy).toHaveBeenCalled();
+    expect(requestPaste).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/webview/terminal/index.ts
+++ b/src/webview/terminal/index.ts
@@ -30,6 +30,20 @@ export interface WheelHandlerOptions {
   scrollLines: (count: number) => void;
 }
 
+export interface ContextMenuPasteHandlerOptions {
+  requestPaste: () => void;
+}
+
+export function createContextMenuPasteHandler(
+  options: ContextMenuPasteHandlerOptions,
+) {
+  return (event: MouseEvent): void => {
+    event.preventDefault();
+    event.stopPropagation();
+    options.requestPaste();
+  };
+}
+
 export function createWheelHandler(options: WheelHandlerOptions) {
   return (event: WheelEvent): void => {
     if (!options.isWindows() || event.ctrlKey || event.deltaY === 0) {
@@ -59,9 +73,11 @@ export function initTerminal(
 ): TerminalInstance | null {
   const config = readTerminalConfig(container);
 
-  container.addEventListener("contextmenu", (event) => {
-    event.preventDefault();
+  const requestPaste = () => postMessage({ type: "triggerPaste" });
+  const contextMenuHandler = createContextMenuPasteHandler({
+    requestPaste,
   });
+  container.addEventListener("contextmenu", contextMenuHandler);
 
   const terminal = new Terminal({
     cursorBlink: config.cursorBlink,
@@ -77,7 +93,7 @@ export function initTerminal(
 
   const keyboardHandler = createKeyboardHandler({
     sendInput: (data) => options.onData(data),
-    requestPaste: () => postMessage({ type: "triggerPaste" }),
+    requestPaste,
     hasSelection: () => terminal.hasSelection(),
     copySelection: () => {
       const selection = terminal.getSelection();
@@ -192,6 +208,7 @@ export function initTerminal(
   const dispose = () => {
     cleanupResize();
     cleanupVisibility();
+    container.removeEventListener("contextmenu", contextMenuHandler);
     container.removeEventListener("focusin", refreshTerminal);
     container.removeEventListener("click", refreshTerminal);
     container.removeEventListener("wheel", wheelHandler, true);

--- a/src/webview/terminal/keyboard.test.ts
+++ b/src/webview/terminal/keyboard.test.ts
@@ -172,6 +172,42 @@ describe("createKeyboardHandler", () => {
       expect(requestPaste).toHaveBeenCalledTimes(1);
     });
 
+    it("requests host paste for Ctrl+V even when sendKeybindingsToShell is enabled", () => {
+      const requestPaste = vi.fn();
+      expectKeyboardHandling(createKeyboardHandler({
+        isMac: false,
+        requestPaste,
+        sendKeybindingsToShell: true,
+      }), {
+        ctrlKey: true,
+        key: "v",
+        code: "KeyV",
+      }, false, true);
+      expect(requestPaste).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps Ctrl+P with xterm when sendKeybindingsToShell is enabled", () => {
+      expectKeyboardHandling(createKeyboardHandler({
+        isMac: false,
+        sendKeybindingsToShell: true,
+      }), {
+        ctrlKey: true,
+        key: "p",
+        code: "KeyP",
+      }, true, true);
+    });
+
+    it("lets VS Code handle Ctrl+P when sendKeybindingsToShell is disabled", () => {
+      expectKeyboardHandling(createKeyboardHandler({
+        isMac: false,
+        sendKeybindingsToShell: false,
+      }), {
+        ctrlKey: true,
+        key: "p",
+        code: "KeyP",
+      }, false, false);
+    });
+
     it("requests host paste on Ctrl+Shift+V", () => {
       const requestPaste = vi.fn();
       expectKeyboardHandling(createKeyboardHandler({ isMac: false, requestPaste }), {


### PR DESCRIPTION
## Summary
- route terminal right-click/context-menu paste through the existing host paste bridge
- keep paste shortcuts host-handled even when `sendKeybindingsToShell` is enabled
- add regression coverage for right-click paste and Ctrl+V/Ctrl+P routing policy

## ULW plan
- From `plans/triaged-issues-ulw-plan.md`, Wave 2 (#38/#36 input routing)

## Verification
- RED: `npm run test -- src/webview/terminal/index.test.ts src/webview/terminal/keyboard.test.ts` failed before implementation because `createContextMenuPasteHandler` was missing
- GREEN: `npm run test -- src/webview/terminal/index.test.ts src/webview/terminal/keyboard.test.ts`
- GREEN: `npm run test -- src/webview/terminal/index.test.ts src/webview/terminal/keyboard.test.ts src/webview/clipboard/index.test.ts src/providers/MessageRouter.test.ts src/providers/TerminalProvider.test.ts`
- GREEN: `npm run compile`
- GREEN: `npm run lint -- src/webview/terminal/index.ts src/webview/terminal/index.test.ts src/webview/terminal/keyboard.ts src/webview/terminal/keyboard.test.ts`
- GREEN: `npm run compile:e2e`
- GREEN: `git diff --check origin/main...HEAD`
- Manual QA channel: tmux-run targeted terminal input tests passed

## Note
`npm run test:e2e` was also attempted and hit an existing config-count mismatch in `config-comprehensive.e2e` (expected 24 settings, current manifest includes pane settings). This PR does not change extension configuration.
