### PR TITLE
test(e2e): include pane settings in config expectations

### DIFF
--- a/src/test/e2e/suite/config-comprehensive.e2e.ts
+++ b/src/test/e2e/suite/config-comprehensive.e2e.ts
@@ -135,6 +135,21 @@ const configurationSpecs: Record<string, ConfigurationSpec> = {
     type: "boolean",
     defaultValue: true,
   },
+  "opencodeTui.pane.defaultSplitDirection": {
+    type: "string",
+    defaultValue: "horizontal",
+    enumValues: ["horizontal", "vertical"],
+  },
+  "opencodeTui.pane.focusOnClick": { type: "boolean", defaultValue: true },
+  "opencodeTui.pane.showPaneActions": {
+    type: "boolean",
+    defaultValue: true,
+  },
+  "opencodeTui.pane.renderer": {
+    type: "string",
+    defaultValue: "auto",
+    enumValues: ["webgl", "canvas", "auto"],
+  },
 };
 
 function assertConfigurationProperty(
@@ -171,12 +186,12 @@ function assertConfigurationProperty(
 }
 
 suite("Comprehensive configuration contributions", () => {
-  test("contributes exactly the expected 24 configuration properties", async () => {
+  test("contributes exactly the expected configuration properties", async () => {
     const extension = await activateExtension();
     const properties = getConfigurationProperties(extension);
     const expectedPropertyIds = Object.keys(configurationSpecs).sort();
 
-    assert.strictEqual(expectedPropertyIds.length, 24);
+    assert.strictEqual(expectedPropertyIds.length, 28);
     assert.deepStrictEqual(Object.keys(properties).sort(), expectedPropertyIds);
   });
 


### PR DESCRIPTION
## Summary
- update the comprehensive configuration e2e expectation to include the four contributed pane settings
- remove the hardcoded test name count while still asserting the exact property list length

## Why
The final integration run after PR #46/#47 showed `npm run test:e2e` failing because the e2e expected 24 config keys while the manifest currently contributes 28, including pane settings.

## Verification
- GREEN: `npm run compile:e2e`
- GREEN: `npm run lint -- src/test/e2e/suite/config-comprehensive.e2e.ts`
- GREEN: `npm run test:e2e` (68 passing)
- GREEN: `git diff --check`
